### PR TITLE
Fix f-string syntax error with nested quotes

### DIFF
--- a/mcp-server/threat_designer_mcp/server.py
+++ b/mcp-server/threat_designer_mcp/server.py
@@ -38,7 +38,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     try:
         yield AppContext(
             api_client=client,
-            base_endpoint = f"{os.environ.get("API_ENDPOINT")}/threat-designer/mcp"
+            base_endpoint = f'{os.environ.get("API_ENDPOINT")}/threat-designer/mcp'
             )
     finally:
         await client.aclose()


### PR DESCRIPTION
- Replace double quotes with single quotes inside f-string to resolve: SyntaxError caused by unmatched parentheses in os.environ.get() call.
