### PR TITLE
Fixes TypeError in PregelProtocol class where multiple inheritance of

### DIFF
--- a/backend/dependencies/requirements-langchain.txt
+++ b/backend/dependencies/requirements-langchain.txt
@@ -1,4 +1,4 @@
-langchain-aws==0.2.27
-langgraph==0.5.0
+langchain-aws==0.2.28
+langgraph==0.5.3
 structlog==25.4.0
 pydantic-settings==2.10.1


### PR DESCRIPTION
- ABC, Generic, and Runnable created an inconsistent method resolution order. Updated LangGraph dependency to latest version which resolves the base class ordering issue.

