### PR TITLE
feat: add optional custom domain name support for Amplify app

### DIFF
--- a/infra/amplify.tf
+++ b/infra/amplify.tf
@@ -54,3 +54,14 @@ resource "aws_iam_role_policy" "amplify_iam_policy" {
   role   = aws_iam_role.amplify_iam_role.id
   policy = templatefile("${path.module}/templates/amplify_execution_role_policy.json", {})
 }
+
+resource "aws_amplify_domain_association" "domain" {
+  count       = var.custom_domain_name != null ? 1 : 0
+  app_id      = aws_amplify_app.threat-designer.id
+  domain_name = var.custom_domain_name
+
+  sub_domain {
+    branch_name = aws_amplify_branch.develop.branch_name
+    prefix      = ""
+  }
+}

--- a/infra/api_gateway.tf
+++ b/infra/api_gateway.tf
@@ -5,7 +5,7 @@ resource "aws_api_gateway_rest_api" "threat_design_api" {
     lambda_arn     = local.api_lambda_invoke_url,
     authorizer_arn = local.authorizer_invoke_url,
     aws_region     = var.region,
-    ui_domain      = "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"
+    ui_domain      = var.custom_domain_name != null ? "https://${var.custom_domain_name}" : "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"
   })
 
   endpoint_configuration {

--- a/infra/cognito.tf
+++ b/infra/cognito.tf
@@ -58,8 +58,14 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_scopes                 = ["email", "openid", "profile"]
 
   # Using your specific Amplify app domain
-  callback_urls = ["https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"]
-  logout_urls   = ["https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"]
+  callback_urls = concat(
+    ["https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"],
+    var.custom_domain_name != null ? ["https://${var.custom_domain_name}"] : []
+  )
+  logout_urls = concat(
+    ["https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"],
+    var.custom_domain_name != null ? ["https://${var.custom_domain_name}"] : []
+  )
 
   explicit_auth_flows = [
     "ALLOW_USER_SRP_AUTH",

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -23,8 +23,8 @@ resource "aws_lambda_function" "backend" {
     variables = {
       LOG_LEVEL             = "INFO",
       REGION                = var.region,
-      PORTAL_REDIRECT_URL   = "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"
-      TRUSTED_ORIGINS       = "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}, http://localhost:5173"
+      PORTAL_REDIRECT_URL   = var.custom_domain_name != null ? "https://${var.custom_domain_name}" : "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}"
+      TRUSTED_ORIGINS       = var.custom_domain_name != null ? "https://${var.custom_domain_name}, http://localhost:5173" : "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}, http://localhost:5173"
       THREAT_MODELING_AGENT = aws_bedrockagentcore_agent_runtime.threat_designer.agent_runtime_arn,
       AGENT_STATE_TABLE     = aws_dynamodb_table.threat_designer_state.id,
       BACKUP_TABLE          = aws_dynamodb_table.threat_designer_backup.id,

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -9,9 +9,9 @@ locals {
   environment           = var.env
   powertools_layer_arn  = "arn:aws:lambda:${var.region}:017000801446:layer:AWSLambdaPowertoolsPythonV3-${var.python_layer}-x86_64:25"
   python_version        = "python${var.python_runtime}"
-  allowed_origins = [
+  allowed_origins = concat([
     "http://localhost:3000",
     "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}",
     "http://localhost:5173"
-  ]
+  ], var.custom_domain_name != null ? ["https://${var.custom_domain_name}"] : [])
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -431,3 +431,9 @@ variable "kb_embedding_model_id" {
   description = "Bedrock foundation model ID to use for Spaces knowledge base embeddings"
   default     = "amazon.titan-embed-text-v2:0"
 }
+
+variable "custom_domain_name" {
+  type        = string
+  description = "Optional custom domain name to associate with the Amplify app (e.g. app.example.com). If not provided, the default Amplify-generated URL is used."
+  default     = null
+}


### PR DESCRIPTION
## Summary
Adds an optional `custom_domain_name` variable that allows the app to be served 
on a user-defined domain instead of the default Amplify-generated URL.

Closes #112 

## Changes
- `infra/variables.tf` — added optional `custom_domain_name` variable
- `infra/amplify.tf` — added `aws_amplify_domain_association` resource, conditional on `custom_domain_name`
- `infra/locals.tf` — custom domain added to `allowed_origins` when provided
- `infra/lambda.tf` — `PORTAL_REDIRECT_URL` and `TRUSTED_ORIGINS` use custom domain when provided
- `infra/api_gateway.tf` — `ui_domain` uses custom domain when provided
- `infra/cognito.tf` — custom domain added to Cognito `callback_urls` and `logout_urls` when provided

## Behaviour
- If `custom_domain_name` is set, the app is served on that domain with all required configuration wired automatically
- If not provided, behaviour is unchanged — app uses the default Amplify-generated URL