### PR TITLE
feat: support external ECR repositories to decouple image management from Terraform

### DIFF
--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -14,4 +14,17 @@ locals {
     "https://${aws_amplify_branch.develop.branch_name}.${aws_amplify_app.threat-designer.default_domain}",
     "http://localhost:5173"
   ]
+
+  use_external_agent_ecr  = var.external_agent_ecr_arn != ""
+  use_external_sentry_ecr = var.external_sentry_ecr_arn != ""
+
+  # Derive repository URL from ARN: arn:aws:ecr:region:account:repository/name -> account.dkr.ecr.region.amazonaws.com/name
+  external_agent_ecr_url  = local.use_external_agent_ecr ? "${split(":", var.external_agent_ecr_arn)[4]}.dkr.ecr.${split(":", var.external_agent_ecr_arn)[3]}.amazonaws.com/${split("/", var.external_agent_ecr_arn)[1]}" : ""
+  external_sentry_ecr_url = local.use_external_sentry_ecr ? "${split(":", var.external_sentry_ecr_arn)[4]}.dkr.ecr.${split(":", var.external_sentry_ecr_arn)[3]}.amazonaws.com/${split("/", var.external_sentry_ecr_arn)[1]}" : ""
+
+  agent_container_uri  = local.use_external_agent_ecr ? "${local.external_agent_ecr_url}:${var.agent_image_tag}" : "${aws_ecr_repository.threat-designer[0].repository_url}:latest"
+  sentry_container_uri = local.use_external_sentry_ecr ? "${local.external_sentry_ecr_url}:${var.sentry_image_tag}" : "${aws_ecr_repository.sentry[0].repository_url}:latest"
+
+  agent_ecr_arn  = local.use_external_agent_ecr ? var.external_agent_ecr_arn : aws_ecr_repository.threat-designer[0].arn
+  sentry_ecr_arn = local.use_external_sentry_ecr ? var.external_sentry_ecr_arn : aws_ecr_repository.sentry[0].arn
 }

--- a/infra/sentry.tf
+++ b/infra/sentry.tf
@@ -35,7 +35,7 @@ resource "aws_bedrockagentcore_agent_runtime" "sentry" {
   }
   agent_runtime_artifact {
     container_configuration {
-      container_uri = "${aws_ecr_repository.sentry[0].repository_url}:latest"
+      container_uri = local.sentry_container_uri
     }
   }
   network_configuration {
@@ -53,7 +53,7 @@ resource "aws_bedrockagentcore_agent_runtime" "sentry" {
 
 
 resource "aws_ecr_repository" "sentry" {
-  count                = var.enable_sentry ? 1 : 0
+  count                = var.enable_sentry && !local.use_external_sentry_ecr ? 1 : 0
   name                 = "${local.prefix}-sentry"
   image_tag_mutability = "MUTABLE"
   force_delete         = true
@@ -64,7 +64,7 @@ resource "aws_ecr_repository" "sentry" {
 }
 
 resource "null_resource" "docker_build_push" {
-  count      = var.enable_sentry ? 1 : 0
+  count      = var.enable_sentry && !local.use_external_sentry_ecr ? 1 : 0
   depends_on = [aws_ecr_repository.sentry]
 
   triggers = {
@@ -135,7 +135,7 @@ resource "aws_iam_role_policy" "agent_core_policy" {
           "ecr:GetDownloadUrlForLayer"
         ],
         "Resource" : [
-          "${aws_ecr_repository.sentry[0].arn}"
+          "${local.sentry_ecr_arn}"
         ]
       },
       {

--- a/infra/threat_designer_agent_core.tf
+++ b/infra/threat_designer_agent_core.tf
@@ -30,7 +30,7 @@ resource "aws_bedrockagentcore_agent_runtime" "threat_designer" {
   )
   agent_runtime_artifact {
     container_configuration {
-      container_uri = "${aws_ecr_repository.threat-designer.repository_url}:latest"
+      container_uri = local.agent_container_uri
     }
   }
   network_configuration {
@@ -45,6 +45,7 @@ resource "aws_bedrockagentcore_agent_runtime" "threat_designer" {
 
 
 resource "aws_ecr_repository" "threat-designer" {
+  count                = local.use_external_agent_ecr ? 0 : 1
   name                 = "${local.prefix}-agent"
   image_tag_mutability = "MUTABLE"
   force_delete         = true
@@ -55,6 +56,7 @@ resource "aws_ecr_repository" "threat-designer" {
 }
 
 resource "null_resource" "docker_agent_build_push" {
+  count      = local.use_external_agent_ecr ? 0 : 1
   depends_on = [aws_ecr_repository.threat-designer]
 
   triggers = {
@@ -68,14 +70,14 @@ resource "null_resource" "docker_agent_build_push" {
     command     = <<-EOT
       # Get ECR login token
       aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-      aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${aws_ecr_repository.threat-designer.repository_url}
+      aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${aws_ecr_repository.threat-designer[0].repository_url}
       
       # Ensure buildx is set up
       docker buildx create --use --name multiarch 2>/dev/null || docker buildx use multiarch
       
       # Build and push image for ARM64
       docker buildx build --platform linux/arm64 --build-arg AWS_REGION=${var.region} \
-        -t ${aws_ecr_repository.threat-designer.repository_url}:latest \
+        -t ${aws_ecr_repository.threat-designer[0].repository_url}:latest \
         --push .
     EOT
   }
@@ -135,7 +137,7 @@ resource "aws_iam_role_policy" "threat_designer_agent_core_policy" {
           "ecr:GetDownloadUrlForLayer"
         ],
         "Resource" : [
-          "${aws_ecr_repository.threat-designer.arn}"
+          "${local.agent_ecr_arn}"
         ]
       },
       {

--- a/infra/threat_designer_agent_core.tf
+++ b/infra/threat_designer_agent_core.tf
@@ -44,6 +44,16 @@ resource "aws_bedrockagentcore_agent_runtime" "threat_designer" {
 }
 
 
+moved {
+  from = aws_ecr_repository.threat-designer
+  to   = aws_ecr_repository.threat-designer[0]
+}
+
+moved {
+  from = null_resource.docker_agent_build_push
+  to   = null_resource.docker_agent_build_push[0]
+}
+
 resource "aws_ecr_repository" "threat-designer" {
   count                = local.use_external_agent_ecr ? 0 : 1
   name                 = "${local.prefix}-agent"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -431,3 +431,27 @@ variable "kb_embedding_model_id" {
   description = "Bedrock foundation model ID to use for Spaces knowledge base embeddings"
   default     = "amazon.titan-embed-text-v2:0"
 }
+
+variable "external_agent_ecr_arn" {
+  type        = string
+  description = "ARN of an external ECR repository containing the threat designer agent image. When set, skips local ECR creation and docker build."
+  default     = ""
+}
+
+variable "external_sentry_ecr_arn" {
+  type        = string
+  description = "ARN of an external ECR repository containing the sentry assistant image. When set, skips local ECR creation and docker build."
+  default     = ""
+}
+
+variable "agent_image_tag" {
+  type        = string
+  description = "Image tag to use for the threat designer agent container."
+  default     = "latest"
+}
+
+variable "sentry_image_tag" {
+  type        = string
+  description = "Image tag to use for the sentry assistant container."
+  default     = "latest"
+}


### PR DESCRIPTION
## Summary
Adds optional `external_agent_ecr_arn` and `external_sentry_ecr_arn` variables that 
allow users to provide their own ECR repositories instead of having Terraform create 
them and build Docker images during deployment.

Closes #114 

## Changes
- `infra/variables.tf` — added `external_agent_ecr_arn`, `external_sentry_ecr_arn`, `agent_image_tag`, `sentry_image_tag` optional variables
- `infra/locals.tf` — added locals to derive ECR URLs from ARNs and determine which container URI to use
- `infra/threat_designer_agent_core.tf` — ECR creation and Docker build skipped when `external_agent_ecr_arn` is set
- `infra/sentry.tf` — same for sentry

## Behaviour
- If `external_agent_ecr_arn` is provided, Terraform skips creating the ECR repository and building the Docker image — Bedrock AgentCore uses the image from the external ECR directly
- If `external_sentry_ecr_arn` is provided, same behaviour for sentry
- If neither is provided, behaviour is unchanged — ECR repositories are created and images are built from source as before

## Use Case
Enterprise teams that manage their own image lifecycle separately from Terraform — for example building and scanning images in a dedicated CI pipeline — can now provide their own ECR repositories without needing Docker available in the Terraform pipeline.