### PR TITLE
feat: add Excel (.xlsx) and Markdown (.md) export formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",
     "styled-components": "^6.1.15",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "xlsx": "0.18.5"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/quick-start-guide/export-threat-models.md
+++ b/quick-start-guide/export-threat-models.md
@@ -1,0 +1,160 @@
+# Quick Start Guide: Exporting Threat Models
+
+This guide explains how to export your threat models in different formats for various audiences and use cases.
+
+## When to Export
+
+Export your threat model when you need to:
+
+- **Share with stakeholders** who don't have system access
+- **Document security assessments** for compliance or audit purposes
+- **Present findings** to executive leadership or technical teams
+- **Archive threat models** for future reference
+- **Integrate with other tools** via JSON format
+- **Feed into AI/LLM tools** for deeper analysis via Markdown format
+
+---
+
+## Export Formats Comparison
+
+| Format | Best For | Pros | Cons |
+|--------|----------|------|------|
+| **PDF** | Stakeholder presentations, executive reports, compliance documentation | Professional appearance, universally readable, preserves formatting | Not editable, larger file size |
+| **DOCX** | Technical documentation, collaborative editing, customization | Editable in Word, flexible formatting, easy to modify | Requires Microsoft Word or compatible editor |
+| **Excel (.xlsx)** | Data analysis, filtering, pivot tables, spreadsheet workflows | Sortable/filterable, multi-sheet structure, familiar to analysts | Requires Excel or compatible editor |
+| **Markdown (.md)** | AI/LLM integration, developer documentation, version control | AI-readable, lightweight, Git-friendly, human-readable | No rich formatting, no embedded images |
+| **JSON** | Automation, integration, data analysis, custom tooling | Machine-readable, complete data structure, scriptable | Not human-friendly, requires technical knowledge |
+
+---
+
+## How to Export
+
+### Step 1: Access Export Options
+
+1. Open your completed threat model from the Threat Catalog
+2. Click the **Actions** dropdown in the top-right corner
+3. Hover over **Download** to see format options:
+   - PDF
+   - DOCX
+   - Excel (XLSX)
+   - Markdown (.md)
+   - JSON
+
+### Step 2: Select Format
+
+Click your desired format. The file will be generated client-side and downloaded immediately.
+
+---
+
+## Format Details
+
+### PDF Export
+
+Generates a professional report with:
+- Title, description, and metadata
+- Architecture diagram (embedded image)
+- Assumptions list
+- Assets, data flows, trust boundaries, and threat sources
+- Complete threat catalog with all details
+
+**Best for:** Stakeholder presentations, compliance audits, formal documentation.
+
+### DOCX Export
+
+Generates an editable Word document with the same structure as PDF:
+- All sections from your threat model
+- Formatted tables for threats
+- Editable content for further customization
+
+**Best for:** Collaborative editing, adding annotations, creating templates.
+
+### Excel (.xlsx) Export
+
+Generates a multi-sheet workbook:
+
+| Sheet | Contents |
+|-------|----------|
+| **Summary** | Title, description, creation date, reasoning level |
+| **Threats** | Full threat catalog with ID, name, STRIDE category, description, risk score, likelihood, impact, mitigations, ISO controls, affected assets, status, comments |
+| **Assets** | Name, type, description, sensitivity |
+| **Data Flows** | Source, target, description |
+| **Trust Boundaries** | Source, target, purpose |
+| **Assumptions** | Listed assumptions |
+
+**Best for:** Data analysis, sorting/filtering threats, pivot tables, tracking remediation status.
+
+### Markdown (.md) Export
+
+Generates a structured text document:
+- Title, description, and metadata
+- Assumptions as numbered list
+- Assets, data flows, trust boundaries as Markdown tables
+- Threat sources with details
+- Complete threat catalog **sorted by risk score** (High to Low) with:
+  - Attribute tables per threat (STRIDE category, risk score, likelihood, impact, etc.)
+  - Description, affected assets, prerequisites, mitigations, ISO controls
+  - Comments (if any)
+
+**Best for:** AI/LLM analysis, Git-friendly documentation, developer wikis.
+
+### JSON Export
+
+Exports the complete threat model data structure including:
+- All metadata and settings
+- Architecture diagram (base64 encoded)
+- Assets, flows, boundaries, threat sources
+- Full threat catalog with all fields
+
+**Best for:** Tool integration, automation, programmatic access, data migration.
+
+---
+
+## Export Strategies by Audience
+
+### Executive Summary
+- **Format:** PDF
+- **Focus:** High-level risk overview
+- **Tip:** Share only critical and high-risk threats
+
+### Technical Deep-Dive
+- **Format:** DOCX or PDF
+- **Focus:** Complete analysis with all details
+- **Tip:** Include all sections for security engineers
+
+### Compliance Audit
+- **Format:** PDF
+- **Focus:** Risk assessment with ISO27001 control mapping
+- **Tip:** Highlight risk scores and mitigation strategies
+
+### Data Analysis
+- **Format:** Excel (.xlsx)
+- **Focus:** Sorting, filtering, pivot tables
+- **Tip:** Use the Threats sheet to create risk distribution charts
+
+### AI/LLM Analysis
+- **Format:** Markdown (.md)
+- **Focus:** Feed into ChatGPT, Claude, or other AI tools
+- **Tip:** The structured format fits well in AI context windows
+
+### Integration/Automation
+- **Format:** JSON
+- **Focus:** Programmatic access for custom tools
+- **Tip:** Parse the `threat_list.threats` array for threat data
+
+---
+
+## Best Practices
+
+- **Save before exporting** to ensure the latest changes are included
+- **Use descriptive filenames** like `PaymentAPI-2025-01-15-ThreatModel.pdf`
+- **Export after major changes** to maintain version history
+- **Store JSON exports in Git** for version-controlled threat model history
+- **Use Markdown for AI workflows** when you want to analyze threats with LLM tools
+
+---
+
+## Next Steps
+
+- [Interact with Threat Model Results](./interact-with-threat-model-results.md) - Customize your threat model before export
+- [Collaborate on Threat Models](./collaborate-on-threat-models.md) - Share with team members directly in the app
+- [Replay Threat Model](./replay-threat-model.md) - Re-run analysis before exporting updated results

--- a/quick-start-guide/interact-with-threat-model-results.md
+++ b/quick-start-guide/interact-with-threat-model-results.md
@@ -152,7 +152,11 @@ Export your threat model in multiple formats for sharing and documentation:
 
 - **PDF**: Professional report format ideal for stakeholder presentations
 - **DOCX**: Editable document format for further customization in Word
+- **Excel (XLSX)**: Multi-sheet workbook for data analysis, filtering, and pivot tables
+- **Markdown (.md)**: Structured text format for AI/LLM tools, developer docs, and version control
 - **JSON**: Raw structured data for integration with other tools or custom workflows
+
+See the [Export Threat Models](./export-threat-models.md) guide for detailed format comparison and export strategies.
 
 ## Best Practices
 

--- a/src/components/ThreatModeling/ThreatModel.jsx
+++ b/src/components/ThreatModeling/ThreatModel.jsx
@@ -389,6 +389,8 @@ const ThreatModelInner = () => {
         tr: () => handleHelpButtonClick(<InfoContent context={"All"} />),
         "cp-doc": () => handleDownload("docx"),
         "cp-pdf": () => handleDownload("pdf"),
+        "cp-xls": () => handleDownload("xls"),
+        "cp-md": () => handleDownload("md"),
         "cp-json": () => handleDownload("json"),
       };
       await actions[actionId]?.();

--- a/src/components/ThreatModeling/hooks/useThreatModelDownload.js
+++ b/src/components/ThreatModeling/hooks/useThreatModelDownload.js
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { downloadDocument, downloadPDFDocument } from "../docs";
 import createThreatModelingDocument from "../ResultsDocx";
 import { createThreatModelingPDF } from "../ResutlPdf";
+import * as XLSX from "xlsx";
 
 /**
  * Helper function to convert string array to objects with a key
@@ -48,6 +49,400 @@ const downloadJSON = (data, filename, base64Diagram) => {
 };
 
 /**
+ * Helper function to sanitize text for Markdown table cells
+ * - Escapes pipe characters that would break table structure
+ * - Replaces newlines with spaces to keep content on single line
+ * @param {string} text - The text to sanitize
+ * @returns {string} Sanitized text safe for Markdown tables
+ */
+const sanitizeTableCell = (text) => {
+  if (!text) return "";
+  return String(text).replace(/\|/g, "\\|").replace(/\n/g, " ").replace(/\r/g, "");
+};
+
+/**
+ * Helper function to sanitize text for Markdown headings
+ * - Escapes # characters that would create unintended headings
+ * @param {string} text - The text to sanitize
+ * @returns {string} Sanitized text safe for Markdown headings
+ */
+const sanitizeHeading = (text) => {
+  if (!text) return "";
+  return String(text).replace(/#/g, "\\#");
+};
+
+/**
+ * Helper function to download threat model data as Markdown (.md)
+ * AI-friendly format for use with LLMs and AI tools
+ * @param {Object} data - The threat model data
+ * @param {string} filename - The filename for the download
+ */
+const downloadMarkdown = (data, filename) => {
+  // Destructure to exclude sensitive/internal fields (consistent with JSON export)
+  const { job_id, owner, retry, s3_location, ...cleanData } = data || {};
+
+  const lines = [];
+
+  // Title and Description
+  const title = sanitizeHeading(cleanData?.title || "Threat Model Report");
+  lines.push(`# ${title}`);
+  lines.push("");
+  if (cleanData?.description) {
+    lines.push(`## Description`);
+    lines.push("");
+    lines.push(cleanData.description);
+    lines.push("");
+  }
+
+  // Metadata
+  lines.push(`## Metadata`);
+  lines.push("");
+  lines.push(`- **Created:** ${cleanData?.timestamp || "N/A"}`);
+  lines.push(`- **Reasoning Level:** ${cleanData?.retry || "N/A"}`);
+  lines.push("");
+
+  // Assumptions
+  const assumptions = cleanData?.assumptions || [];
+  if (assumptions.length > 0) {
+    lines.push(`## Assumptions`);
+    lines.push("");
+    assumptions.forEach((assumption, index) => {
+      const text = typeof assumption === "string" ? assumption : assumption.assumption || "";
+      lines.push(`${index + 1}. ${text}`);
+    });
+    lines.push("");
+  }
+
+  // Assets
+  const assets = cleanData?.assets?.assets || [];
+  if (assets.length > 0) {
+    lines.push(`## Assets`);
+    lines.push("");
+    lines.push(`| # | Asset Name | Type | Description | Sensitivity |`);
+    lines.push(`|---|------------|------|-------------|-------------|`);
+    assets.forEach((asset, index) => {
+      const name = sanitizeTableCell(asset.name);
+      const type = sanitizeTableCell(asset.type);
+      const desc = sanitizeTableCell(asset.description);
+      const sensitivity = sanitizeTableCell(asset.sensitivity);
+      lines.push(`| ${index + 1} | ${name} | ${type} | ${desc} | ${sensitivity} |`);
+    });
+    lines.push("");
+  }
+
+  // Data Flows
+  const dataFlows = cleanData?.system_architecture?.data_flows || [];
+  if (dataFlows.length > 0) {
+    lines.push(`## Data Flows`);
+    lines.push("");
+    lines.push(`| # | Source | Target | Description |`);
+    lines.push(`|---|--------|--------|-------------|`);
+    dataFlows.forEach((flow, index) => {
+      const source = sanitizeTableCell(flow.source_entity || flow.source);
+      const target = sanitizeTableCell(flow.target_entity || flow.destination);
+      const desc = sanitizeTableCell(flow.flow_description || flow.description);
+      lines.push(`| ${index + 1} | ${source} | ${target} | ${desc} |`);
+    });
+    lines.push("");
+  }
+
+  // Trust Boundaries
+  const trustBoundaries = cleanData?.system_architecture?.trust_boundaries || [];
+  if (trustBoundaries.length > 0) {
+    lines.push(`## Trust Boundaries`);
+    lines.push("");
+    lines.push(`| # | Source | Target | Purpose |`);
+    lines.push(`|---|--------|--------|---------|`);
+    trustBoundaries.forEach((boundary, index) => {
+      const source = sanitizeTableCell(boundary.source_entity || boundary.name);
+      const target = sanitizeTableCell(boundary.target_entity || boundary.type);
+      const purpose = sanitizeTableCell(boundary.purpose || boundary.description);
+      lines.push(`| ${index + 1} | ${source} | ${target} | ${purpose} |`);
+    });
+    lines.push("");
+  }
+
+  // Threat Sources
+  const threatSources = cleanData?.system_architecture?.threat_sources || [];
+  if (threatSources.length > 0) {
+    lines.push(`## Threat Sources`);
+    lines.push("");
+    threatSources.forEach((source, index) => {
+      const sourceName = sanitizeHeading(source.category || source.name || "Unknown Source");
+      lines.push(`### ${index + 1}. ${sourceName}`);
+      lines.push("");
+      if (source.description) {
+        lines.push(source.description);
+        lines.push("");
+      }
+      if (source.motivation) {
+        lines.push(`- **Motivation:** ${source.motivation}`);
+      }
+      if (source.capability) {
+        lines.push(`- **Capability:** ${source.capability}`);
+      }
+      lines.push("");
+    });
+  }
+
+  // Threat Catalog (main section)
+  const threats = cleanData?.threat_list?.threats || [];
+  if (threats.length > 0) {
+    lines.push(`## Threat Catalog`);
+    lines.push("");
+    lines.push(`Total Threats: ${threats.length}`);
+    lines.push("");
+
+    // Sort threats by risk score (High to Low)
+    const riskScoreOrder = {
+      High: 5,
+      "Medium/High": 4,
+      Medium: 3,
+      "Low/Medium": 2,
+      Low: 1,
+    };
+    const sortedThreats = [...threats].sort((a, b) => {
+      const scoreA = riskScoreOrder[a?.risk_score] || 0;
+      const scoreB = riskScoreOrder[b?.risk_score] || 0;
+      return scoreB - scoreA;
+    });
+
+    sortedThreats.forEach((threat, index) => {
+      // Sanitize threat name for heading (escape # characters)
+      const threatName = sanitizeHeading(threat.threat_name || threat.name || "Unnamed Threat");
+      lines.push(`### ${index + 1}. ${threatName}`);
+      lines.push("");
+
+      // Risk information - sanitize values for table cells
+      lines.push(`| Attribute | Value |`);
+      lines.push(`|-----------|-------|`);
+      lines.push(`| **STRIDE Category** | ${sanitizeTableCell(threat.stride_category || "N/A")} |`);
+      lines.push(`| **Risk Score** | ${sanitizeTableCell(threat.risk_score || "N/A")} |`);
+      lines.push(`| **Likelihood** | ${sanitizeTableCell(threat.likelihood || "N/A")} |`);
+      lines.push(`| **Impact** | ${sanitizeTableCell(threat.impact || "N/A")} |`);
+      lines.push(`| **Target** | ${sanitizeTableCell(threat.target || "N/A")} |`);
+      lines.push(`| **Source** | ${sanitizeTableCell(threat.source || "N/A")} |`);
+      lines.push(`| **Attack Vector** | ${sanitizeTableCell(threat.vector || "N/A")} |`);
+      lines.push(`| **Status** | ${sanitizeTableCell(threat.status || "To do")} |`);
+      lines.push("");
+
+      // Description
+      if (threat.description) {
+        lines.push(`**Description:**`);
+        lines.push("");
+        lines.push(threat.description);
+        lines.push("");
+      }
+
+      // Affected Assets
+      const affectedAssets = threat.affected_assets || [];
+      if (affectedAssets.length > 0) {
+        lines.push(`**Affected Assets:**`);
+        lines.push("");
+        affectedAssets.forEach((asset) => {
+          const sanitizedAsset = String(asset || "")
+            .replace(/\n/g, " ")
+            .replace(/\r/g, "");
+          lines.push(`- ${sanitizedAsset}`);
+        });
+        lines.push("");
+      }
+
+      // Prerequisites (array field)
+      const prerequisites = threat.prerequisites || [];
+      if (prerequisites.length > 0) {
+        lines.push(`**Prerequisites:**`);
+        lines.push("");
+        prerequisites.forEach((prereq) => {
+          const sanitizedPrereq = String(prereq || "")
+            .replace(/\n/g, " ")
+            .replace(/\r/g, "");
+          lines.push(`- ${sanitizedPrereq}`);
+        });
+        lines.push("");
+      }
+
+      // Mitigations (plural array field)
+      const mitigations = threat.mitigations || [];
+      if (mitigations.length > 0) {
+        lines.push(`**Mitigations:**`);
+        lines.push("");
+        mitigations.forEach((mitigation) => {
+          const sanitizedMitigation = String(mitigation || "")
+            .replace(/\n/g, " ")
+            .replace(/\r/g, "");
+          lines.push(`- ${sanitizedMitigation}`);
+        });
+        lines.push("");
+      }
+
+      // ISO27001 Controls
+      const isoControls = threat.iso_controls || [];
+      if (isoControls.length > 0) {
+        lines.push(`**ISO27001 Controls:**`);
+        lines.push("");
+        if (Array.isArray(isoControls)) {
+          isoControls.forEach((control) => {
+            const sanitizedControl = String(control || "")
+              .replace(/\n/g, " ")
+              .replace(/\r/g, "");
+            lines.push(`- ${sanitizedControl}`);
+          });
+        } else {
+          const sanitizedControl = String(isoControls || "")
+            .replace(/\n/g, " ")
+            .replace(/\r/g, "");
+          lines.push(`- ${sanitizedControl}`);
+        }
+        lines.push("");
+      }
+
+      // Comments (user notes)
+      if (threat.comments) {
+        lines.push(`**Comments:**`);
+        lines.push("");
+        lines.push(threat.comments);
+        lines.push("");
+      }
+
+      lines.push("---");
+      lines.push("");
+    });
+  }
+
+  // Generate and download the file
+  const markdownContent = lines.join("\n");
+  const blob = new Blob([markdownContent], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${filename || "threat-model"}.md`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+/**
+ * Helper function to download threat model data as Excel (.xlsx)
+ * Multi-sheet workbook with Summary, Threats, Assets, Data Flows, Trust Boundaries, Assumptions
+ * @param {Object} data - The threat model data
+ * @param {string} filename - The filename for the download
+ */
+const downloadXLS = (data, filename) => {
+  const workbook = XLSX.utils.book_new();
+
+  // Sheet 1: Summary
+  const summaryData = [
+    ["Threat Model Summary"],
+    [""],
+    ["Title", data?.title || ""],
+    ["Description", data?.description || ""],
+    ["Created", data?.timestamp || ""],
+    ["Reasoning Level", data?.retry || ""],
+  ];
+  const summarySheet = XLSX.utils.aoa_to_sheet(summaryData);
+  XLSX.utils.book_append_sheet(workbook, summarySheet, "Summary");
+
+  // Sheet 2: Threats (main data)
+  const threats = data?.threat_list?.threats || [];
+  if (threats.length > 0) {
+    const threatHeaders = [
+      "ID",
+      "Threat Name",
+      "Category",
+      "Description",
+      "Risk Score",
+      "Likelihood",
+      "Impact",
+      "Mitigation",
+      "ISO27001 Controls",
+      "Affected Assets",
+      "Status",
+      "Comments",
+    ];
+    const threatRows = threats.map((threat, index) => [
+      index + 1,
+      threat.threat_name || threat.name || "",
+      threat.stride_category || "",
+      threat.description || "",
+      threat.risk_score || "",
+      threat.likelihood || "",
+      threat.impact || "",
+      Array.isArray(threat.mitigations) ? threat.mitigations.join(", ") : threat.mitigation || "",
+      Array.isArray(threat.iso_controls)
+        ? threat.iso_controls.join(", ")
+        : threat.iso_controls || "",
+      Array.isArray(threat.affected_assets)
+        ? threat.affected_assets.join(", ")
+        : threat.affected_assets || "",
+      threat.status || "",
+      threat.comments || "",
+    ]);
+    const threatSheet = XLSX.utils.aoa_to_sheet([threatHeaders, ...threatRows]);
+    XLSX.utils.book_append_sheet(workbook, threatSheet, "Threats");
+  }
+
+  // Sheet 3: Assets
+  const assets = data?.assets?.assets || [];
+  if (assets.length > 0) {
+    const assetHeaders = ["ID", "Asset Name", "Type", "Description", "Sensitivity"];
+    const assetRows = assets.map((asset, index) => [
+      index + 1,
+      asset.name || "",
+      asset.type || "",
+      asset.description || "",
+      asset.sensitivity || "",
+    ]);
+    const assetSheet = XLSX.utils.aoa_to_sheet([assetHeaders, ...assetRows]);
+    XLSX.utils.book_append_sheet(workbook, assetSheet, "Assets");
+  }
+
+  // Sheet 4: Data Flows
+  const dataFlows = data?.system_architecture?.data_flows || [];
+  if (dataFlows.length > 0) {
+    const flowHeaders = ["ID", "Source", "Target", "Description"];
+    const flowRows = dataFlows.map((flow, index) => [
+      index + 1,
+      flow.source_entity || flow.source || "",
+      flow.target_entity || flow.destination || "",
+      flow.flow_description || flow.description || "",
+    ]);
+    const flowSheet = XLSX.utils.aoa_to_sheet([flowHeaders, ...flowRows]);
+    XLSX.utils.book_append_sheet(workbook, flowSheet, "Data Flows");
+  }
+
+  // Sheet 5: Trust Boundaries
+  const trustBoundaries = data?.system_architecture?.trust_boundaries || [];
+  if (trustBoundaries.length > 0) {
+    const boundaryHeaders = ["ID", "Source", "Target", "Purpose"];
+    const boundaryRows = trustBoundaries.map((boundary, index) => [
+      index + 1,
+      boundary.source_entity || boundary.name || "",
+      boundary.target_entity || boundary.type || "",
+      boundary.purpose || boundary.description || "",
+    ]);
+    const boundarySheet = XLSX.utils.aoa_to_sheet([boundaryHeaders, ...boundaryRows]);
+    XLSX.utils.book_append_sheet(workbook, boundarySheet, "Trust Boundaries");
+  }
+
+  // Sheet 6: Assumptions
+  const assumptions = data?.assumptions || [];
+  if (assumptions.length > 0) {
+    const assumptionHeaders = ["ID", "Assumption"];
+    const assumptionRows = assumptions.map((assumption, index) => [
+      index + 1,
+      typeof assumption === "string" ? assumption : assumption.assumption || "",
+    ]);
+    const assumptionSheet = XLSX.utils.aoa_to_sheet([assumptionHeaders, ...assumptionRows]);
+    XLSX.utils.book_append_sheet(workbook, assumptionSheet, "Assumptions");
+  }
+
+  // Generate and download the file
+  XLSX.writeFile(workbook, `${filename || "threat-model"}.xlsx`);
+};
+
+/**
  * Custom hook for handling threat model document downloads
  *
  * @param {Object} response - The threat model response data
@@ -59,11 +454,13 @@ const downloadJSON = (data, filename, base64Diagram) => {
  * handleDownload('pdf'); // Download as PDF
  * handleDownload('docx'); // Download as DOCX
  * handleDownload('json'); // Download as JSON
+ * handleDownload('xls'); // Download as Excel
+ * handleDownload('md'); // Download as Markdown
  */
 export const useThreatModelDownload = (response, base64Content) => {
   /**
    * Handle document download in specified format
-   * @param {string} format - The format to download ('docx', 'pdf', or 'json')
+   * @param {string} format - The format to download ('docx', 'pdf', 'json', 'xls', or 'md')
    */
   const handleDownload = useCallback(
     async (format = "docx") => {
@@ -71,6 +468,18 @@ export const useThreatModelDownload = (response, base64Content) => {
         // Handle JSON export separately (no need for doc generation)
         if (format === "json") {
           downloadJSON(response?.item, response?.item?.title, base64Content);
+          return;
+        }
+
+        // Handle Excel export separately
+        if (format === "xls") {
+          downloadXLS(response?.item, response?.item?.title);
+          return;
+        }
+
+        // Handle Markdown export separately
+        if (format === "md") {
+          downloadMarkdown(response?.item, response?.item?.title);
           return;
         }
 

--- a/src/components/ThreatModeling/hooks/useThreatModelDownload.js
+++ b/src/components/ThreatModeling/hooks/useThreatModelDownload.js
@@ -118,14 +118,14 @@ const downloadMarkdown = (data, filename) => {
   if (assets.length > 0) {
     lines.push(`## Assets`);
     lines.push("");
-    lines.push(`| # | Asset Name | Type | Description | Sensitivity |`);
+    lines.push(`| # | Asset Name | Type | Description | Criticality |`);
     lines.push(`|---|------------|------|-------------|-------------|`);
     assets.forEach((asset, index) => {
       const name = sanitizeTableCell(asset.name);
       const type = sanitizeTableCell(asset.type);
       const desc = sanitizeTableCell(asset.description);
-      const sensitivity = sanitizeTableCell(asset.sensitivity);
-      lines.push(`| ${index + 1} | ${name} | ${type} | ${desc} | ${sensitivity} |`);
+      const criticality = sanitizeTableCell(asset.criticality);
+      lines.push(`| ${index + 1} | ${name} | ${type} | ${desc} | ${criticality} |`);
     });
     lines.push("");
   }
@@ -193,23 +193,21 @@ const downloadMarkdown = (data, filename) => {
     lines.push(`Total Threats: ${threats.length}`);
     lines.push("");
 
-    // Sort threats by risk score (High to Low)
-    const riskScoreOrder = {
-      High: 5,
-      "Medium/High": 4,
-      Medium: 3,
-      "Low/Medium": 2,
+    // Sort threats by likelihood (High to Low)
+    const likelihoodOrder = {
+      High: 3,
+      Medium: 2,
       Low: 1,
     };
     const sortedThreats = [...threats].sort((a, b) => {
-      const scoreA = riskScoreOrder[a?.risk_score] || 0;
-      const scoreB = riskScoreOrder[b?.risk_score] || 0;
+      const scoreA = likelihoodOrder[a?.likelihood] || 0;
+      const scoreB = likelihoodOrder[b?.likelihood] || 0;
       return scoreB - scoreA;
     });
 
     sortedThreats.forEach((threat, index) => {
       // Sanitize threat name for heading (escape # characters)
-      const threatName = sanitizeHeading(threat.threat_name || threat.name || "Unnamed Threat");
+      const threatName = sanitizeHeading(threat.name || "Unnamed Threat");
       lines.push(`### ${index + 1}. ${threatName}`);
       lines.push("");
 
@@ -217,13 +215,11 @@ const downloadMarkdown = (data, filename) => {
       lines.push(`| Attribute | Value |`);
       lines.push(`|-----------|-------|`);
       lines.push(`| **STRIDE Category** | ${sanitizeTableCell(threat.stride_category || "N/A")} |`);
-      lines.push(`| **Risk Score** | ${sanitizeTableCell(threat.risk_score || "N/A")} |`);
       lines.push(`| **Likelihood** | ${sanitizeTableCell(threat.likelihood || "N/A")} |`);
       lines.push(`| **Impact** | ${sanitizeTableCell(threat.impact || "N/A")} |`);
       lines.push(`| **Target** | ${sanitizeTableCell(threat.target || "N/A")} |`);
       lines.push(`| **Source** | ${sanitizeTableCell(threat.source || "N/A")} |`);
       lines.push(`| **Attack Vector** | ${sanitizeTableCell(threat.vector || "N/A")} |`);
-      lines.push(`| **Status** | ${sanitizeTableCell(threat.status || "To do")} |`);
       lines.push("");
 
       // Description
@@ -231,20 +227,6 @@ const downloadMarkdown = (data, filename) => {
         lines.push(`**Description:**`);
         lines.push("");
         lines.push(threat.description);
-        lines.push("");
-      }
-
-      // Affected Assets
-      const affectedAssets = threat.affected_assets || [];
-      if (affectedAssets.length > 0) {
-        lines.push(`**Affected Assets:**`);
-        lines.push("");
-        affectedAssets.forEach((asset) => {
-          const sanitizedAsset = String(asset || "")
-            .replace(/\n/g, " ")
-            .replace(/\r/g, "");
-          lines.push(`- ${sanitizedAsset}`);
-        });
         lines.push("");
       }
 
@@ -276,32 +258,11 @@ const downloadMarkdown = (data, filename) => {
         lines.push("");
       }
 
-      // ISO27001 Controls
-      const isoControls = threat.iso_controls || [];
-      if (isoControls.length > 0) {
-        lines.push(`**ISO27001 Controls:**`);
+      // Notes (user annotations)
+      if (threat.notes) {
+        lines.push(`**Notes:**`);
         lines.push("");
-        if (Array.isArray(isoControls)) {
-          isoControls.forEach((control) => {
-            const sanitizedControl = String(control || "")
-              .replace(/\n/g, " ")
-              .replace(/\r/g, "");
-            lines.push(`- ${sanitizedControl}`);
-          });
-        } else {
-          const sanitizedControl = String(isoControls || "")
-            .replace(/\n/g, " ")
-            .replace(/\r/g, "");
-          lines.push(`- ${sanitizedControl}`);
-        }
-        lines.push("");
-      }
-
-      // Comments (user notes)
-      if (threat.comments) {
-        lines.push(`**Comments:**`);
-        lines.push("");
-        lines.push(threat.comments);
+        lines.push(threat.notes);
         lines.push("");
       }
 
@@ -349,35 +310,31 @@ const downloadXLS = (data, filename) => {
   if (threats.length > 0) {
     const threatHeaders = [
       "ID",
-      "Threat Name",
-      "Category",
+      "Name",
+      "STRIDE Category",
       "Description",
-      "Risk Score",
+      "Target",
       "Likelihood",
       "Impact",
-      "Mitigation",
-      "ISO27001 Controls",
-      "Affected Assets",
-      "Status",
-      "Comments",
+      "Source",
+      "Attack Vector",
+      "Prerequisites",
+      "Mitigations",
+      "Notes",
     ];
     const threatRows = threats.map((threat, index) => [
       index + 1,
-      threat.threat_name || threat.name || "",
+      threat.name || "",
       threat.stride_category || "",
       threat.description || "",
-      threat.risk_score || "",
+      threat.target || "",
       threat.likelihood || "",
       threat.impact || "",
-      Array.isArray(threat.mitigations) ? threat.mitigations.join(", ") : threat.mitigation || "",
-      Array.isArray(threat.iso_controls)
-        ? threat.iso_controls.join(", ")
-        : threat.iso_controls || "",
-      Array.isArray(threat.affected_assets)
-        ? threat.affected_assets.join(", ")
-        : threat.affected_assets || "",
-      threat.status || "",
-      threat.comments || "",
+      threat.source || "",
+      threat.vector || "",
+      Array.isArray(threat.prerequisites) ? threat.prerequisites.join(", ") : "",
+      Array.isArray(threat.mitigations) ? threat.mitigations.join(", ") : "",
+      threat.notes || "",
     ]);
     const threatSheet = XLSX.utils.aoa_to_sheet([threatHeaders, ...threatRows]);
     XLSX.utils.book_append_sheet(workbook, threatSheet, "Threats");
@@ -386,13 +343,13 @@ const downloadXLS = (data, filename) => {
   // Sheet 3: Assets
   const assets = data?.assets?.assets || [];
   if (assets.length > 0) {
-    const assetHeaders = ["ID", "Asset Name", "Type", "Description", "Sensitivity"];
+    const assetHeaders = ["ID", "Asset Name", "Type", "Description", "Criticality"];
     const assetRows = assets.map((asset, index) => [
       index + 1,
       asset.name || "",
       asset.type || "",
       asset.description || "",
-      asset.sensitivity || "",
+      asset.criticality || "",
     ]);
     const assetSheet = XLSX.utils.aoa_to_sheet([assetHeaders, ...assetRows]);
     XLSX.utils.book_append_sheet(workbook, assetSheet, "Assets");

--- a/src/components/ThreatModeling/threatmodel/ThreatModelActions.jsx
+++ b/src/components/ThreatModeling/threatmodel/ThreatModelActions.jsx
@@ -94,6 +94,16 @@ const ThreatModelActions = React.memo(
               disabled: !showResults,
             },
             {
+              text: "Excel (XLSX)",
+              id: "cp-xls",
+              disabled: !showResults,
+            },
+            {
+              text: "Markdown (.md)",
+              id: "cp-md",
+              disabled: !showResults,
+            },
+            {
               text: "JSON",
               id: "cp-json",
               disabled: !showResults,

--- a/src/data/guides.js
+++ b/src/data/guides.js
@@ -8,6 +8,7 @@ import usingSentryMd from "../../quick-start-guide/using-sentry.md?raw";
 import usingSpacesMd from "../../quick-start-guide/using-spaces.md?raw";
 import versioningThreatModelsMd from "../../quick-start-guide/versioning-threat-models.md?raw";
 import collaborateMd from "../../quick-start-guide/collaborate-on-threat-models.md?raw";
+import exportThreatModelsMd from "../../quick-start-guide/export-threat-models.md?raw";
 
 // Guide metadata and content mapping
 export const guides = {
@@ -46,6 +47,10 @@ export const guides = {
   "collaborate-on-threat-models": {
     title: "Collaborate on Threat Models",
     content: collaborateMd,
+  },
+  "export-threat-models": {
+    title: "Export Threat Models",
+    content: exportThreatModelsMd,
   },
 };
 


### PR DESCRIPTION
## Summary

Adds two new download options to the threat model export menu:

- **Excel (.xlsx)**: Multi-sheet workbook with Summary, Threats, Assets, Data Flows, Trust Boundaries, and Assumptions sheets
- **Markdown (.md)**: Structured document with tables, threats sorted by likelihood (High to Low), and sanitized content for safe markdown rendering. AI-friendly format for use with LLMs and AI tools.

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `xlsx` 0.18.5 dependency |
| `useThreatModelDownload.js` | Add `downloadMarkdown()`, `downloadXLS()`, `sanitizeTableCell()`, `sanitizeHeading()` helpers; handle `xls` and `md` formats |
| `ThreatModelActions.jsx` | Add "Excel (XLSX)" and "Markdown (.md)" to download dropdown |
| `ThreatModel.jsx` | Wire `cp-xls` and `cp-md` action IDs to `handleDownload` |
| `quick-start-guide/export-threat-models.md` | New guide: format comparison, export instructions, audience strategies |
| `quick-start-guide/interact-with-threat-model-results.md` | Updated Download section to list all 5 formats |
| `src/data/guides.js` | Register new export guide in app guide viewer |

## What is NOT modified

- Existing PDF, DOCX, and JSON export functionality remains completely unchanged
- No backend changes
- No infrastructure changes
- No changes to existing UI components or layout

## Testing

- `npm run build` passes cleanly (0 errors)
- All existing lint warnings are pre-existing (Blob/URL globals not in eslint config - same issue in existing `docs.jsx`)
- Feature is purely additive — new menu items + new client-side generation functions

## Data Model Consistency (Review Feedback Addressed)

Both new export formats now use **only fields from the canonical threat data model** (`backend/threat_designer/state.py`), consistent with the existing PDF/DOCX/JSON exports:

### Threat fields used

`name`, `stride_category`, `description`, `target`, `impact`, `likelihood`, `mitigations`, `source`, `prerequisites`, `vector`, `notes`

### Asset fields used

`type`, `name`, `description`, `criticality`

### Data Flow fields used

`flow_description`, `source_entity`, `target_entity`

### Trust Boundary fields used

`purpose`, `source_entity`, `target_entity`

### Fields removed (did not exist in data model)

- `status` — not a threat field
- `risk_score` — not a computed field (only `likelihood` + `impact` exist separately)
- `iso_controls` — not in the data model
- `affected_assets` — not a threat field
- `threat_name` — renamed to correct field `name`
- `comments` — renamed to correct field `notes`
- `sensitivity` (Assets) — renamed to correct field `criticality`

## Excel export details

Creates a multi-sheet workbook:

1. **Summary** — Title, description, timestamps
2. **Threats** — Name, STRIDE category, description, target, likelihood, impact, source, attack vector, prerequisites, mitigations, notes
3. **Assets** — Name, type, description, criticality
4. **Data Flows** — Source, target, description
5. **Trust Boundaries** — Source, target, purpose
6. **Assumptions** — Listed assumptions

## Markdown export details

Generates a structured .md file including:

- Metadata, assumptions, assets table, data flows table, trust boundaries table, threat sources
- Full threat catalog sorted by likelihood (High to Low) with attribute tables, mitigations, prerequisites
- Proper sanitization (escaped pipes for tables, escaped `#` for headings)

## Documentation

Added a new **Export Threat Models** quick-start guide covering:

- Format comparison table (PDF vs DOCX vs Excel vs Markdown vs JSON)
- Step-by-step export instructions
- Format-specific details (what each format includes)
- Export strategies by audience (Executive, Technical, Compliance, Data Analysis, AI/LLM, Automation)
- Best practices for file naming, version control, and content selection

Updated the existing **Interact with Results** guide to reference all 5 download formats and link to the new export guide.
