### PR TITLE
fix: resolve unresolvable langgraph pin blocking container builds

### DIFF
--- a/backend/sentry/requirements.txt
+++ b/backend/sentry/requirements.txt
@@ -1,5 +1,5 @@
 
-langgraph==1.1.6
+langgraph>=1.2.4,<1.3.0
 langchain-aws==1.4.3
 langchain-openai==1.1.14
 langchain-tavily>=0.2.16

--- a/backend/threat_designer/requirements.txt
+++ b/backend/threat_designer/requirements.txt
@@ -1,4 +1,4 @@
-langgraph==1.1.6
+langgraph>=1.2.4,<1.3.0
 langchain-aws==1.4.3
 langchain-openai==1.1.14
 langchain==1.3.9


### PR DESCRIPTION
## Summary

- `backend/threat_designer/requirements.txt` and `backend/sentry/requirements.txt` both pin `langgraph==1.1.6` while also pinning `langchain==1.3.9`, which requires `langgraph>=1.2.4,<1.3.0`. The two pins are mutually unsatisfiable.
- This isn't just a local dev annoyance — it fails `pip install -r requirements.txt` **inside the Dockerfile build** for both AgentCore runtimes (main agent and Sentry), so a fresh deploy of either container currently cannot succeed on `main`.
- Fix: widen `langgraph` to the range `langchain` actually requires (`>=1.2.4,<1.3.0`).

## How this was found / verified

Found while testing #143 (MAESTRO) end-to-end against a real AWS account — `terraform apply` failed rebuilding the AgentCore containers with `ResolutionImpossible`. Confirmed the same conflict exists independently on `main` (this PR's branch touches no other files). After the fix:

- Both AgentCore Docker images (`threat_designer_agent`, `threat_designer_sentry`) build and push successfully.
- `test/threat_designer` suite (47 tests) passes unaffected.

## Test plan

- [x] `pip install -r backend/threat_designer/requirements.txt` resolves
- [x] `pip install -r backend/sentry/requirements.txt` resolves
- [x] Both AgentCore Docker images build successfully
- [x] `pytest test/threat_designer` — 47 passed