### PR TITLE
fix(auth): align password special-char check with Cognito symbol set

### DIFF
--- a/src/components/Auth/LoginForm.css
+++ b/src/components/Auth/LoginForm.css
@@ -175,6 +175,21 @@
   color: #5cb85c;
 }
 
+.password-requirements {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  font-size: 12px;
+  text-align: left;
+}
+
+.password-requirements li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.8;
+}
+
 /* Disabled button styles */
 .button-group button:disabled {
   opacity: 0.7;

--- a/src/components/Auth/LoginForm.jsx
+++ b/src/components/Auth/LoginForm.jsx
@@ -12,6 +12,27 @@ const Title = styled.h1`
   margin-bottom: 40px;
 `;
 
+const REQUIREMENT_LABELS = {
+  minLength: "At least 8 characters",
+  hasUpperCase: "An uppercase letter",
+  hasLowerCase: "A lowercase letter",
+  hasNumber: "A number",
+  hasSpecialChar: "A special character",
+};
+
+const PasswordRequirements = ({ requirements }) => (
+  <ul className="password-requirements">
+    {Object.entries(REQUIREMENT_LABELS).map(([key, label]) => (
+      <li key={key}>
+        <span className={`validation-icon ${requirements[key] ? "valid" : ""}`}>
+          {requirements[key] ? "✓" : "✗"}
+        </span>
+        {label}
+      </li>
+    ))}
+  </ul>
+);
+
 const LoginForm = ({ onSignInSuccess }) => {
   const { isDark } = useTheme();
   const [username, setUsername] = useState("");
@@ -39,7 +60,10 @@ const LoginForm = ({ onSignInSuccess }) => {
       hasUpperCase: /[A-Z]/.test(password),
       hasLowerCase: /[a-z]/.test(password),
       hasNumber: /\d/.test(password),
-      hasSpecialChar: /[!@#$%^&*(),.?":{}|<>]/.test(password),
+      // Must match the Cognito symbol set, otherwise passwords the pool accepts
+      // never enable the submit button (issue #142):
+      // ^ $ * . [ ] { } ( ) ? - " ! @ # % & / \ , > < ' : ; | _ ~ ` + =
+      hasSpecialChar: /[\^$*.[\]{}()?\-"!@#%&/\\,><':;|_~`+=]/.test(password),
     };
 
     return {
@@ -99,6 +123,7 @@ const LoginForm = ({ onSignInSuccess }) => {
       await resetPassword({ username });
       setConfirmNewPassword("");
       setNewPassword("");
+      setPasswordValidation(validatePassword(""));
       setFormState("resetPassword");
     } catch (error) {
       setError(error.message || "Error initiating password reset");
@@ -155,6 +180,7 @@ const LoginForm = ({ onSignInSuccess }) => {
             <div className="form-group">
               <label>New Password</label>
               <input type="password" value={newPassword} onChange={handlePasswordChange} required />
+              <PasswordRequirements requirements={passwordValidation.requirements} />
             </div>
             <div className="button-group">
               <GenAiButton loading={loading} disabled={!passwordValidation.isValid}>
@@ -226,6 +252,7 @@ const LoginForm = ({ onSignInSuccess }) => {
             <div className="form-group">
               <label>New Password</label>
               <input type="password" value={newPassword} onChange={handlePasswordChange} required />
+              <PasswordRequirements requirements={passwordValidation.requirements} />
             </div>
             <div className="form-group">
               <label>Confirm New Password</label>


### PR DESCRIPTION
The Set New Password button is gated on a client-side validator whose special-character regex accepted only !@#$%^&*(),.?":{}|<> — a subset of the symbols the Cognito user pool accepts for require_symbols. A password using -, _, +, =, /, \, ', ;, ~, `, [ or ] as its only symbol satisfies the pool policy but never enabled the button, leaving it permanently disabled on first login. Fixes #142.

The validator now matches Cognito's documented symbol set, and both the new-password and reset-password forms render a live requirements checklist (the validation state and icon styles already existed but were never wired into the UI), so an unmet requirement is visible instead of presenting as a dead button. Stale validation state is also cleared when entering the reset-password flow.
