### PR TITLE
feat: add MAESTRO methodology support to the frontend

### DIFF
--- a/e2e/tests/wizard/create.spec.ts
+++ b/e2e/tests/wizard/create.spec.ts
@@ -45,5 +45,52 @@ test("submits a threat model through the 5-step wizard", async ({ authenticatedP
   expect(postBody).toMatchObject({
     title: "My E2E Threat Model",
     application_type: "hybrid",
+    methodology: "stride",
+  });
+});
+
+test("submits a MAESTRO threat model via the methodology selector", async ({
+  authenticatedPage,
+}) => {
+  let postBody: unknown = null;
+  await authenticatedPage.route(
+    /http:\/\/mock\.local\/api\/threat-designer\/?(\?.*)?$/,
+    async (route) => {
+      if (route.request().method() !== "POST") return route.fallback();
+      postBody = route.request().postDataJSON();
+      return route.fulfill({ json: { id: "tm-new-2", job_id: "tm-new-2" } });
+    }
+  );
+
+  await authenticatedPage.goto("/");
+  await authenticatedPage.getByRole("button", { name: "Submit Threat Model" }).click();
+  const wizard = authenticatedPage.getByTestId("submission-wizard");
+  await expect(wizard).toBeVisible();
+
+  // Step 1 — Title
+  await wizard.getByLabel("Threat model title").fill("My MAESTRO Threat Model");
+  await authenticatedPage.getByRole("button", { name: "Next" }).click();
+
+  // Step 2 — Primary diagram upload
+  await wizard.locator('input[type="file"]').first().setInputFiles(DIAGRAM);
+  await authenticatedPage.getByRole("button", { name: "Next" }).click();
+
+  // Step 3 — Details: switch methodology from the STRIDE default to MAESTRO
+  await wizard.getByRole("button", { name: "Methodology STRIDE" }).click();
+  await authenticatedPage.getByRole("option", { name: /MAESTRO/ }).click();
+  await authenticatedPage.getByRole("button", { name: "Next" }).click();
+
+  // Steps 4 + 5 — Agent config and assumptions (defaults)
+  await authenticatedPage.getByRole("button", { name: "Next" }).click();
+  await authenticatedPage.getByRole("button", { name: "Next" }).click();
+
+  // Step 6 — Review shows the chosen methodology, then submit
+  await expect(wizard.getByLabel("Methodology")).toHaveValue("MAESTRO (agentic AI)");
+  await authenticatedPage.getByRole("button", { name: /Start threat modeling/i }).click();
+
+  await expect(authenticatedPage).toHaveURL(/\/tm-new-2$/);
+  expect(postBody).toMatchObject({
+    title: "My MAESTRO Threat Model",
+    methodology: "maestro",
   });
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:e2e": "cross-env VITE_E2E_MOCK=true VITE_APP_ENDPOINT=http://mock.local/api VITE_COGNITO_REGION=us-east-1 VITE_USER_POOL_ID=us-east-1_MOCK VITE_APP_CLIENT_ID=mock-client VITE_COGNITO_DOMAIN=mock.auth.local VITE_REDIRECT_SIGN_IN=http://localhost:5173 VITE_REDIRECT_SIGN_OUT=http://localhost:5173 VITE_SENTRY_ENABLED=false vite --port 5173 --strictPort",
+    "dev:e2e": "cross-env VITE_E2E_MOCK=true VITE_APP_ENDPOINT=http://mock.local/api VITE_COGNITO_REGION=us-east-1 VITE_USER_POOL_ID=us-east-1_MOCK VITE_APP_CLIENT_ID=mock-client VITE_COGNITO_DOMAIN=mock.auth.local VITE_REDIRECT_SIGN_IN=http://localhost:5173 VITE_REDIRECT_SIGN_OUT=http://localhost:5173 VITE_SENTRY_ENABLED=false VITE_MAESTRO_ENABLED=true vite --port 5173 --strictPort",
     "build": "vite build",
     "preview": "vite preview",
     "start:local": "vite --mode development",

--- a/src/components/ThreatModeling/ExportOptionsModal.jsx
+++ b/src/components/ThreatModeling/ExportOptionsModal.jsx
@@ -48,7 +48,13 @@ const defaultLikelihoodFilter = {
   Low: true,
 };
 
-export const ExportOptionsModal = ({ visible, onDismiss, onExport, format }) => {
+export const ExportOptionsModal = ({
+  visible,
+  onDismiss,
+  onExport,
+  format,
+  methodology = "stride",
+}) => {
   // Section selections
   const [sections, setSections] = useState(defaultSections);
   // Column selections (for Threat Catalog table)
@@ -82,7 +88,7 @@ export const ExportOptionsModal = ({ visible, onDismiss, onExport, format }) => 
   // Column labels (mapped to canonical field names)
   const columnLabels = {
     name: "Threat Name",
-    strideCategory: "STRIDE Category",
+    strideCategory: methodology === "maestro" ? "MAESTRO Layer" : "STRIDE Category",
     description: "Description",
     target: "Target",
     likelihood: "Likelihood",

--- a/src/components/ThreatModeling/ResultsComponent.jsx
+++ b/src/components/ThreatModeling/ResultsComponent.jsx
@@ -31,9 +31,11 @@ const ThreatModelingOutput = memo(function ThreatModelingOutput({
   updateTM,
   refreshTrail,
   isReadOnly = false,
+  methodology = "stride",
 }) {
   const [openModal, setOpenModal] = useState(false);
   const [query, setQuery] = useState({ tokens: [], operation: "and" });
+  const categoryFieldKey = methodology === "maestro" ? "maestro_layer" : "stride_category";
   const { id = null } = useParams();
   const { handleHelpButtonClick } = useSplitPanel();
 
@@ -128,12 +130,19 @@ const ThreatModelingOutput = memo(function ThreatModelingOutput({
         groupValuesLabel: "Source values",
         operators: ["=", "!="],
       },
-      {
-        key: "stride_category",
-        propertyLabel: "STRIDE Category",
-        groupValuesLabel: "STRIDE categories",
-        operators: ["=", "!="],
-      },
+      methodology === "maestro"
+        ? {
+            key: "maestro_layer",
+            propertyLabel: "MAESTRO Layer",
+            groupValuesLabel: "MAESTRO layers",
+            operators: ["=", "!="],
+          }
+        : {
+            key: "stride_category",
+            propertyLabel: "STRIDE Category",
+            groupValuesLabel: "STRIDE categories",
+            operators: ["=", "!="],
+          },
       {
         key: "starred",
         propertyLabel: "Starred",
@@ -155,7 +164,7 @@ const ThreatModelingOutput = memo(function ThreatModelingOutput({
     }
 
     return baseProperties;
-  }, [treesLoading, treesError]);
+  }, [treesLoading, treesError, methodology]);
 
   // Generate filter options dynamically from threat data
   const filteringOptions = useMemo(() => {
@@ -377,6 +386,7 @@ const ThreatModelingOutput = memo(function ThreatModelingOutput({
             updateTM={updateTM}
             onOpenAttackTree={handleOpenAttackTree}
             isReadOnly={isReadOnly}
+            methodology={methodology}
           />
         </SpaceBetween>
       </SpaceBetween>
@@ -385,7 +395,7 @@ const ThreatModelingOutput = memo(function ThreatModelingOutput({
           "name",
           "description",
           "likelihood",
-          "stride_category",
+          categoryFieldKey,
           "impact",
           "target",
           "source",
@@ -403,7 +413,7 @@ const ThreatModelingOutput = memo(function ThreatModelingOutput({
         type={"threats"}
         hasColumn={true}
         columnConfig={{
-          left: ["name", "description", "likelihood", "stride_category", "impact", "target"],
+          left: ["name", "description", "likelihood", categoryFieldKey, "impact", "target"],
           right: ["source", "vector", "prerequisites", "mitigations", "notes"],
         }}
       />

--- a/src/components/ThreatModeling/ResultsDocx.jsx
+++ b/src/components/ThreatModeling/ResultsDocx.jsx
@@ -579,7 +579,8 @@ const createThreatModelingDocument = async (
   dataFlowData,
   trustBoundaryData,
   threatSourceData,
-  threatCatalogData
+  threatCatalogData,
+  methodology = "stride"
 ) => {
   const spacer = new Paragraph({
     text: "",
@@ -607,6 +608,7 @@ const createThreatModelingDocument = async (
       trustBoundaryData,
       threatSourceData,
       threatCatalogData,
+      methodology,
     });
 
     const mainSections = sections.filter((s) => !s.landscape);

--- a/src/components/ThreatModeling/ResutlPdf.jsx
+++ b/src/components/ThreatModeling/ResutlPdf.jsx
@@ -456,7 +456,8 @@ export const createThreatModelingPDF = async (
   dataFlowData,
   trustBoundaryData,
   threatSourceData,
-  threatCatalogData
+  threatCatalogData,
+  methodology = "stride"
 ) => {
   const doc = new jsPDF();
   let yPos = 20;
@@ -579,7 +580,7 @@ export const createThreatModelingPDF = async (
       // Special handling for threat catalog (7 columns)
       if (numColumns === 7) {
         columnStyles[0] = { cellWidth: 45 }; // name
-        columnStyles[1] = { cellWidth: 30 }; // stride_category
+        columnStyles[1] = { cellWidth: 30 }; // stride_category / maestro_layer
         columnStyles[2] = { cellWidth: 70 }; // description
         columnStyles[3] = { cellWidth: 35 }; // target
         columnStyles[4] = { cellWidth: 25 }; // impact
@@ -777,6 +778,7 @@ export const createThreatModelingPDF = async (
     trustBoundaryData,
     threatSourceData,
     threatCatalogData,
+    methodology,
   });
 
   sections.forEach((section) => {

--- a/src/components/ThreatModeling/SubmissionForm.jsx
+++ b/src/components/ThreatModeling/SubmissionForm.jsx
@@ -19,6 +19,8 @@ import Slider from "@cloudscape-design/components/slider";
 import FileTokenGroup from "@cloudscape-design/components/file-token-group";
 import Textarea from "@cloudscape-design/components/textarea";
 import { listSpaces } from "../../services/Spaces/spacesService";
+import { isMaestroEnabled } from "../../config.js";
+import { MAESTRO_LAYER_DESCRIPTIONS } from "./methodologyUtils";
 
 function convertArrayToObjects(arr) {
   return arr.map((item) => ({
@@ -61,6 +63,10 @@ export const SubmissionComponent = ({
   const [applicationType, setApplicationType] = React.useState({
     label: "Hybrid",
     value: "hybrid",
+  });
+  const [methodology, setMethodology] = React.useState({
+    label: "STRIDE",
+    value: "stride",
   });
   const [spaces, setSpaces] = React.useState([]);
   const [selectedSpaceOption, setSelectedSpaceOption] = React.useState(null);
@@ -132,7 +138,8 @@ export const SubmissionComponent = ({
           text,
           assumptions,
           applicationType.value,
-          selectedSpaceOption?.value || null
+          selectedSpaceOption?.value || null,
+          isMaestroEnabled() ? methodology.value : "stride"
         );
       }}
       steps={[
@@ -242,6 +249,45 @@ export const SubmissionComponent = ({
                     onChange={({ detail }) => setApplicationType(detail.selectedOption)}
                   />
                 </FormField>
+                {isMaestroEnabled() && (
+                  <FormField
+                    label="Methodology"
+                    info={
+                      <Popover
+                        header="Methodology"
+                        content={
+                          <SpaceBetween size="s">
+                            <Box>
+                              <Box variant="h5">STRIDE</Box>
+                              General-purpose threat classification (Spoofing, Tampering,
+                              Repudiation, Information Disclosure, Denial of Service, Elevation of
+                              Privilege). Use for most systems.
+                            </Box>
+                            <Box>
+                              <Box variant="h5">MAESTRO</Box>
+                              CSA's threat framework for agentic AI systems, classifying threats
+                              across seven layers (
+                              {Object.keys(MAESTRO_LAYER_DESCRIPTIONS).join(", ")}). Use when the
+                              architecture involves LLM agents, tool use, or agent-to-agent
+                              interaction.
+                            </Box>
+                          </SpaceBetween>
+                        }
+                      >
+                        <Link variant="info">Info</Link>
+                      </Popover>
+                    }
+                  >
+                    <Select
+                      options={[
+                        { label: "STRIDE", value: "stride" },
+                        { label: "MAESTRO (agentic AI)", value: "maestro" },
+                      ]}
+                      selectedOption={methodology}
+                      onChange={({ detail }) => setMethodology(detail.selectedOption)}
+                    />
+                  </FormField>
+                )}
                 <FormField
                   label="Space"
                   constraintText="Optional — attach a knowledge base to enrich threat modeling context."
@@ -507,6 +553,11 @@ export const SubmissionComponent = ({
                     <FormField label="Application type">
                       <Input value={applicationType.label} disabled />
                     </FormField>
+                    {isMaestroEnabled() && (
+                      <FormField label="Methodology">
+                        <Input value={methodology.label} disabled />
+                      </FormField>
+                    )}
                     {selectedSpaceOption && (
                       <FormField label="Space">
                         <Input value={selectedSpaceOption.label} disabled />

--- a/src/components/ThreatModeling/SubmissionForm.jsx
+++ b/src/components/ThreatModeling/SubmissionForm.jsx
@@ -256,10 +256,10 @@ export const SubmissionComponent = ({
                               </Box>
                               <Box>
                                 <Box variant="h5">MAESTRO</Box>
-                                CSA's threat framework for agentic AI systems, classifying threats
-                                across seven layers plus a cross-layer threat class. Use when the
-                                architecture involves LLM agents, tool use, or agent-to-agent
-                                interaction.
+                                CSA&apos;s threat framework for agentic AI systems, classifying
+                                threats across seven layers plus a cross-layer threat class. Use
+                                when the architecture involves LLM agents, tool use, or
+                                agent-to-agent interaction.
                               </Box>
                               {Object.entries(MAESTRO_LAYER_DESCRIPTIONS).map(
                                 ([layer, description]) => (

--- a/src/components/ThreatModeling/ThreatCatalog.jsx
+++ b/src/components/ThreatModeling/ThreatCatalog.jsx
@@ -92,11 +92,11 @@ export const ThreatComponent = React.memo((props) => {
                   position="top"
                   size="small"
                   triggerType="custom"
-                  content={props?.data?.stride_category}
+                  content={props?.data?.stride_category ?? props?.data?.maestro_layer}
                 >
                   <Button
                     variant="icon"
-                    ariaLabel="Stride category"
+                    ariaLabel={props?.data?.maestro_layer ? "MAESTRO layer" : "STRIDE category"}
                     fullWidth
                     iconSvg={CategoryIcon()}
                   ></Button>
@@ -160,7 +160,8 @@ export const ThreatComponent = React.memo((props) => {
                     <strong>Likelihood:</strong> {props?.data?.likelihood}
                   </div>
                   <div>
-                    <strong>Category:</strong> {props?.data?.stride_category}
+                    <strong>Category:</strong>{" "}
+                    {props?.data?.stride_category ?? props?.data?.maestro_layer}
                   </div>
                   <div>
                     <strong>Impact:</strong> {props?.data?.impact}
@@ -205,7 +206,14 @@ export const ThreatComponent = React.memo((props) => {
         type={props?.type}
         hasColumn={true}
         columnConfig={{
-          left: ["name", "description", "likelihood", "stride_category", "impact", "target"],
+          left: [
+            "name",
+            "description",
+            "likelihood",
+            props?.methodology === "maestro" ? "maestro_layer" : "stride_category",
+            "impact",
+            "target",
+          ],
           right: ["source", "vector", "prerequisites", "mitigations", "notes"],
         }}
       />

--- a/src/components/ThreatModeling/ThreatModel.jsx
+++ b/src/components/ThreatModeling/ThreatModel.jsx
@@ -475,6 +475,7 @@ const ThreatModelInner = () => {
           parentId={parentId}
           parentTitle={parentData?.title || parentId}
           onCompare={parentData ? handleCompare : undefined}
+          methodology={resolveMethodology(response?.item)}
         />
         <ThreatModelAlerts
           alert={alert}

--- a/src/components/ThreatModeling/ThreatModel.jsx
+++ b/src/components/ThreatModeling/ThreatModel.jsx
@@ -13,6 +13,7 @@ import ConflictResolutionModal from "./ConflictResolutionModal";
 import VersionCompareModal from "./VersionCompareModal";
 import { ExportOptionsModal } from "./ExportOptionsModal";
 import { InfoContent } from "../HelpPanel/InfoContent";
+import { resolveMethodology } from "./methodologyUtils";
 import {
   ThreatModelProvider,
   useThreatModelContext,
@@ -558,6 +559,7 @@ const ThreatModelInner = () => {
         format={exportModal.format || "pdf"}
         onDismiss={() => setExportModal({ visible: false, format: null })}
         onExport={handleExportWithOptions}
+        methodology={resolveMethodology(response?.item)}
       />
     </>
   );

--- a/src/components/ThreatModeling/ThreatModelDashboard.jsx
+++ b/src/components/ThreatModeling/ThreatModelDashboard.jsx
@@ -8,11 +8,13 @@ import ColumnLayout from "@cloudscape-design/components/column-layout";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import {
   aggregateByStrideWithLikelihood,
+  aggregateByMaestroWithLikelihood,
   aggregateByLikelihood,
   aggregateByTargetWithLikelihood,
   aggregateBySource,
 } from "./chartUtils";
 import StrideChart from "./charts/StrideChart";
+import MaestroChart from "./charts/MaestroChart";
 import LikelihoodChart from "./charts/LikelihoodChart";
 import TargetAssetChart from "./charts/TargetAssetChart";
 import ThreatSourceChart from "./charts/ThreatSourceChart";
@@ -23,7 +25,8 @@ import ChartErrorBoundary from "./charts/ChartErrorBoundary";
  *
  * Container component that displays statistical visualizations of threat model data.
  * Aggregates threat catalog data and renders multiple chart components showing
- * distributions across STRIDE categories, likelihood levels, target assets, and threat sources.
+ * distributions across STRIDE categories or MAESTRO layers (depending on methodology),
+ * likelihood levels, target assets, and threat sources.
  *
  * Features:
  * - Responsive grid layout (2 columns desktop, 1 column mobile)
@@ -44,15 +47,20 @@ const formatTokenCount = (n) => {
 };
 
 // LocalStorage key for persisting board layout
-const BOARD_LAYOUT_KEY = "threatModelDashboardLayout";
+// v2: "stride-chart" was renamed to "category-chart" when MAESTRO support was
+// added, since the same board item now renders either chart depending on the
+// threat model's methodology. Bumping the key lets old saved layouts (which
+// reference the pre-rename id) fall back to defaults once instead of
+// permanently failing the loadBoardLayout() hasAllItems check below.
+const BOARD_LAYOUT_KEY = "threatModelDashboardLayout.v2";
 
 // Default board items configuration
 const getDefaultBoardItems = () => [
   {
-    id: "stride-chart",
+    id: "category-chart",
     rowSpan: 5,
     columnSpan: 2,
-    data: { type: "stride" },
+    data: { type: "category" },
   },
   {
     id: "likelihood-chart",
@@ -94,7 +102,11 @@ const loadBoardLayout = () => {
   return getDefaultBoardItems();
 };
 
-const ThreatModelDashboard = ({ threatCatalogData = [], tokenUsage = null }) => {
+const ThreatModelDashboard = ({
+  threatCatalogData = [],
+  tokenUsage = null,
+  methodology = "stride",
+}) => {
   // Validate input data and filter out malformed threat objects
   const validThreats = useMemo(() => {
     if (!Array.isArray(threatCatalogData)) {
@@ -123,10 +135,12 @@ const ThreatModelDashboard = ({ threatCatalogData = [], tokenUsage = null }) => 
     return filtered;
   }, [threatCatalogData]);
 
-  // Aggregate data for STRIDE category distribution with likelihood breakdown
-  const strideDistribution = useMemo(() => {
-    return aggregateByStrideWithLikelihood(validThreats);
-  }, [validThreats]);
+  // Aggregate data for category (STRIDE or MAESTRO) distribution with likelihood breakdown
+  const categoryDistribution = useMemo(() => {
+    return methodology === "maestro"
+      ? aggregateByMaestroWithLikelihood(validThreats)
+      : aggregateByStrideWithLikelihood(validThreats);
+  }, [validThreats, methodology]);
 
   // Aggregate data for likelihood level distribution
   const likelihoodDistribution = useMemo(() => {
@@ -222,20 +236,29 @@ const ThreatModelDashboard = ({ threatCatalogData = [], tokenUsage = null }) => 
         ]}
         renderItem={(item) => {
           switch (item.data.type) {
-            case "stride":
+            case "category": {
+              const chartName =
+                methodology === "maestro"
+                  ? "Threats by MAESTRO Layer"
+                  : "Threats by STRIDE Category";
               return (
                 <BoardItem
-                  header={<Header>Threats by STRIDE Category</Header>}
+                  header={<Header>{chartName}</Header>}
                   i18nStrings={{
                     dragHandleAriaLabel: "Drag handle",
                     resizeHandleAriaLabel: "Resize handle",
                   }}
                 >
-                  <ChartErrorBoundary chartName="Threats by STRIDE Category">
-                    <StrideChart data={strideDistribution} />
+                  <ChartErrorBoundary chartName={chartName}>
+                    {methodology === "maestro" ? (
+                      <MaestroChart data={categoryDistribution} />
+                    ) : (
+                      <StrideChart data={categoryDistribution} />
+                    )}
                   </ChartErrorBoundary>
                 </BoardItem>
               );
+            }
             case "likelihood":
               return (
                 <BoardItem
@@ -307,6 +330,7 @@ const ThreatModelDashboard = ({ threatCatalogData = [], tokenUsage = null }) => 
  */
 const arePropsEqual = (prevProps, nextProps) => {
   if (prevProps.tokenUsage !== nextProps.tokenUsage) return false;
+  if (prevProps.methodology !== nextProps.methodology) return false;
 
   // Handle null/undefined cases
   if (!prevProps.threatCatalogData && !nextProps.threatCatalogData) {

--- a/src/components/ThreatModeling/ThreatModeling.jsx
+++ b/src/components/ThreatModeling/ThreatModeling.jsx
@@ -26,7 +26,8 @@ export default function ThreatModeling() {
     description,
     assumptions,
     applicationType,
-    spaceId = null
+    spaceId = null,
+    methodology = "stride"
   ) => {
     setLoading(true);
     try {
@@ -60,7 +61,8 @@ export default function ThreatModeling() {
         null, // instructions
         filesArray[0]?.type, // imageType (first file for backward compat)
         applicationType,
-        spaceId
+        spaceId,
+        methodology
       );
       setLoading(false);
       setId(response.data.id);

--- a/src/components/ThreatModeling/VirtualizedThreatList.jsx
+++ b/src/components/ThreatModeling/VirtualizedThreatList.jsx
@@ -18,7 +18,10 @@ const VirtualizedThreatList = memo(function VirtualizedThreatList({
   updateTM,
   onOpenAttackTree,
   isReadOnly,
+  methodology = "stride",
 }) {
+  const categoryFieldKey = methodology === "maestro" ? "maestro_layer" : "stride_category";
+
   const renderThreat = (item, filteredIndex) => {
     // Find the original index in the unfiltered array
     // This ensures delete/edit operations work on the correct threat
@@ -54,7 +57,7 @@ const VirtualizedThreatList = memo(function VirtualizedThreatList({
           "name",
           "description",
           "likelihood",
-          "stride_category",
+          categoryFieldKey,
           "impact",
           "target",
           "source",
@@ -65,6 +68,7 @@ const VirtualizedThreatList = memo(function VirtualizedThreatList({
         ]}
         isReadOnly={isReadOnly}
         onOpenAttackTree={onOpenAttackTree}
+        methodology={methodology}
       />
     );
   };

--- a/src/components/ThreatModeling/chartUtils.js
+++ b/src/components/ThreatModeling/chartUtils.js
@@ -190,6 +190,50 @@ export const aggregateByStrideWithLikelihood = (threats) => {
 };
 
 /**
+ * Transform threat data for MAESTRO layer chart with likelihood breakdown
+ * Returns data structured for stacked bar chart
+ * @param {Array} threats - Array of threat objects
+ * @returns {Object} Object with categories array and series data by likelihood
+ */
+export const aggregateByMaestroWithLikelihood = (threats) => {
+  if (!Array.isArray(threats)) {
+    return { categories: [], series: [] };
+  }
+
+  const categories = [
+    "Foundation Models",
+    "Data Operations",
+    "Agent Frameworks",
+    "Deployment and Infrastructure",
+    "Evaluation and Observability",
+    "Security and Compliance",
+    "Agent Ecosystem",
+    "Cross-Layer",
+  ];
+
+  const likelihoodLevels = ["High", "Medium", "Low"];
+
+  // Create series for each likelihood level
+  const series = likelihoodLevels.map((level) => {
+    const data = categories.map((category) => {
+      const count = threats.filter(
+        (t) => t?.maestro_layer === category && t?.likelihood === level
+      ).length;
+      return { x: category, y: count };
+    });
+
+    return {
+      title: level,
+      type: "bar",
+      data,
+      color: getLikelihoodColor(level),
+    };
+  });
+
+  return { categories, series };
+};
+
+/**
  * Transform threat data for target asset chart with likelihood breakdown
  * Returns data structured for stacked bar chart (top 10 targets)
  * @param {Array} threats - Array of threat objects

--- a/src/components/ThreatModeling/charts/MaestroChart.jsx
+++ b/src/components/ThreatModeling/charts/MaestroChart.jsx
@@ -6,9 +6,10 @@ import Box from "@cloudscape-design/components/box";
  * MaestroChart Component
  *
  * Displays a horizontal stacked bar chart showing the distribution of threats across
- * the eight CSA MAESTRO layers (Foundation Models, Data Operations, Agent Frameworks,
+ * the seven CSA MAESTRO layers (Foundation Models, Data Operations, Agent Frameworks,
  * Deployment and Infrastructure, Evaluation and Observability, Security and Compliance,
- * Agent Ecosystem, Cross-Layer), broken down by likelihood level.
+ * Agent Ecosystem) plus the framework's Cross-Layer threat class, broken down by
+ * likelihood level.
  *
  * Horizontal bars (unlike StrideChart's vertical layout) because MAESTRO layer names
  * run longer than STRIDE category names and don't fit legibly on a vertical axis.
@@ -37,7 +38,7 @@ const MaestroChart = ({ data = { categories: [], series: [] } }) => {
         </Box>
       }
       ariaLabel="Stacked bar chart showing the distribution of threats across MAESTRO layers by likelihood"
-      ariaDescription="Horizontal stacked bar chart displaying threat counts for each of the eight MAESTRO layers, broken down by likelihood level: High (red), Medium (orange), and Low (blue)"
+      ariaDescription="Horizontal stacked bar chart displaying threat counts for the seven MAESTRO layers plus the cross-layer threat class, broken down by likelihood level: High (red), Medium (orange), and Low (yellow)"
       height={300}
       hideFilter
     />

--- a/src/components/ThreatModeling/charts/MaestroChart.jsx
+++ b/src/components/ThreatModeling/charts/MaestroChart.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import BarChart from "@cloudscape-design/components/bar-chart";
+import Box from "@cloudscape-design/components/box";
+
+/**
+ * MaestroChart Component
+ *
+ * Displays a horizontal stacked bar chart showing the distribution of threats across
+ * the eight CSA MAESTRO layers (Foundation Models, Data Operations, Agent Frameworks,
+ * Deployment and Infrastructure, Evaluation and Observability, Security and Compliance,
+ * Agent Ecosystem, Cross-Layer), broken down by likelihood level.
+ *
+ * Horizontal bars (unlike StrideChart's vertical layout) because MAESTRO layer names
+ * run longer than STRIDE category names and don't fit legibly on a vertical axis.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {Object} props.data - Object with categories array and series data
+ * @param {Array} props.data.categories - Array of MAESTRO layer names
+ * @param {Array} props.data.series - Array of series objects with likelihood data
+ * @returns {JSX.Element} The rendered MAESTRO layer chart
+ */
+const MaestroChart = ({ data = { categories: [], series: [] } }) => {
+  const { categories, series } = data;
+
+  return (
+    <BarChart
+      series={series}
+      xDomain={categories}
+      yTitle="Number of Threats"
+      xTitle="MAESTRO Layer"
+      horizontalBars={true}
+      stackedBars={true}
+      empty={
+        <Box textAlign="center" color="text-status-inactive" role="status" aria-live="polite">
+          No threats categorized
+        </Box>
+      }
+      ariaLabel="Stacked bar chart showing the distribution of threats across MAESTRO layers by likelihood"
+      ariaDescription="Horizontal stacked bar chart displaying threat counts for each of the eight MAESTRO layers, broken down by likelihood level: High (red), Medium (orange), and Low (blue)"
+      height={300}
+      hideFilter
+    />
+  );
+};
+
+/**
+ * Custom comparison function for React.memo.
+ * data is {categories, series}, not an array, so compare the series contents directly
+ * rather than treating it as an indexable array (see StrideChart.jsx for the bug this avoids).
+ */
+const arePropsEqual = (prevProps, nextProps) => {
+  const prevData = prevProps.data;
+  const nextData = nextProps.data;
+
+  if (prevData === nextData) return true;
+  if (!prevData || !nextData) return false;
+
+  if (prevData.categories.length !== nextData.categories.length) return false;
+  if (prevData.series.length !== nextData.series.length) return false;
+
+  for (let i = 0; i < prevData.categories.length; i++) {
+    if (prevData.categories[i] !== nextData.categories[i]) return false;
+  }
+
+  for (let i = 0; i < prevData.series.length; i++) {
+    const prevSeries = prevData.series[i];
+    const nextSeries = nextData.series[i];
+    if (prevSeries.title !== nextSeries.title) return false;
+    if (prevSeries.data.length !== nextSeries.data.length) return false;
+    for (let j = 0; j < prevSeries.data.length; j++) {
+      if (
+        prevSeries.data[j].x !== nextSeries.data[j].x ||
+        prevSeries.data[j].y !== nextSeries.data[j].y
+      ) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+// Memoize the component with custom comparison to prevent unnecessary re-renders
+export default React.memo(MaestroChart, arePropsEqual);

--- a/src/components/ThreatModeling/charts/StrideChart.jsx
+++ b/src/components/ThreatModeling/charts/StrideChart.jsx
@@ -11,7 +11,7 @@ import Box from "@cloudscape-design/components/box";
  *
  * Features:
  * - Vertical stacked bar chart showing likelihood breakdown
- * - Color-coded by likelihood: High (red), Medium (orange), Low (blue)
+ * - Color-coded by likelihood: High (red), Medium (orange), Low (yellow)
  * - Empty state handling when no threats are categorized
  * - Accessibility support with ARIA labels
  * - Integration with Cloudscape Design System
@@ -40,7 +40,7 @@ const StrideChart = ({ data = { categories: [], series: [] } }) => {
         </Box>
       }
       ariaLabel="Stacked bar chart showing the distribution of threats across STRIDE categories by likelihood"
-      ariaDescription="Vertical stacked bar chart displaying threat counts for each of the six STRIDE categories, broken down by likelihood level: High (red), Medium (orange), and Low (blue)"
+      ariaDescription="Vertical stacked bar chart displaying threat counts for each of the six STRIDE categories, broken down by likelihood level: High (red), Medium (orange), and Low (yellow)"
       height={300}
       hideFilter
     />

--- a/src/components/ThreatModeling/documentHelpers.js
+++ b/src/components/ThreatModeling/documentHelpers.js
@@ -28,6 +28,15 @@ export const TABLE_COLUMNS = {
     "likelihood",
     "mitigations",
   ],
+  THREAT_CATALOG_MAESTRO: [
+    "name",
+    "maestro_layer",
+    "description",
+    "target",
+    "impact",
+    "likelihood",
+    "mitigations",
+  ],
 };
 
 /**
@@ -56,7 +65,10 @@ export const getDocumentSections = (data) => {
     trustBoundaryData,
     threatSourceData,
     threatCatalogData,
+    methodology = "stride",
   } = data;
+  const threatCatalogColumns =
+    methodology === "maestro" ? TABLE_COLUMNS.THREAT_CATALOG_MAESTRO : TABLE_COLUMNS.THREAT_CATALOG;
 
   return [
     {
@@ -103,7 +115,7 @@ export const getDocumentSections = (data) => {
     {
       type: "table",
       title: SECTION_TITLES.THREAT_CATALOG,
-      columns: TABLE_COLUMNS.THREAT_CATALOG,
+      columns: threatCatalogColumns,
       data: threatCatalogData,
       show: threatCatalogData?.length > 0,
       landscape: true,

--- a/src/components/ThreatModeling/filterUtils.js
+++ b/src/components/ThreatModeling/filterUtils.js
@@ -51,7 +51,7 @@ export function hasAttackTree(threat, threatsWithTrees) {
  * - likelihood: exact match filtering
  * - target: array support with "any element matches" logic
  * - source: array support with "any element matches" logic
- * - stride_category: exact match filtering
+ * - stride_category / maestro_layer: exact match filtering
  * - starred: boolean logic with undefined/null treated as false
  * - has_attack_tree: boolean logic based on threatsWithTrees Set
  *
@@ -107,8 +107,12 @@ export function matchesToken(threat, token, threatsWithTrees = new Set()) {
     return values.some((item) => matchesOperator(item, operator, value));
   }
 
-  // Property-specific filtering: likelihood and stride_category exact match
-  if (propertyKey === "likelihood" || propertyKey === "stride_category") {
+  // Property-specific filtering: likelihood, stride_category, and maestro_layer exact match
+  if (
+    propertyKey === "likelihood" ||
+    propertyKey === "stride_category" ||
+    propertyKey === "maestro_layer"
+  ) {
     // Use exact match comparison
     return matchesOperator(threatValue, operator, value);
   }

--- a/src/components/ThreatModeling/hooks/useThreatModelData.js
+++ b/src/components/ThreatModeling/hooks/useThreatModelData.js
@@ -87,9 +87,10 @@ export const useThreatModelData = (
         return acc;
       }, {});
 
-      // Calculate STRIDE distribution
+      // Calculate category distribution (STRIDE category or MAESTRO layer, whichever the threat carries)
       const strideCounts = threats.reduce((acc, threat) => {
-        acc[threat.stride_category] = (acc[threat.stride_category] || 0) + 1;
+        const category = threat.stride_category ?? threat.maestro_layer;
+        acc[category] = (acc[category] || 0) + 1;
         return acc;
       }, {});
 

--- a/src/components/ThreatModeling/hooks/useThreatModelDownload.js
+++ b/src/components/ThreatModeling/hooks/useThreatModelDownload.js
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { downloadDocument, downloadPDFDocument } from "../docs";
 import createThreatModelingDocument from "../ResultsDocx";
 import { createThreatModelingPDF } from "../ResutlPdf";
+import { resolveMethodology } from "../methodologyUtils";
 import * as XLSX from "xlsx";
 
 /**
@@ -86,6 +87,7 @@ const sanitizeHeading = (text) => {
 const downloadMarkdown = (data, filename) => {
   // Destructure to exclude sensitive/internal fields (consistent with JSON export)
   const { job_id, owner, retry, s3_location, ...cleanData } = data || {};
+  const methodology = resolveMethodology(cleanData);
 
   const lines = [];
 
@@ -225,7 +227,9 @@ const downloadMarkdown = (data, filename) => {
       const tableRows = [];
       if (isColumnSelected("strideCategory"))
         tableRows.push(
-          `| **STRIDE Category** | ${sanitizeTableCell(threat.stride_category || "N/A")} |`
+          methodology === "maestro"
+            ? `| **MAESTRO Layer** | ${sanitizeTableCell(threat.maestro_layer || "N/A")} |`
+            : `| **STRIDE Category** | ${sanitizeTableCell(threat.stride_category || "N/A")} |`
         );
       if (isColumnSelected("likelihood"))
         tableRows.push(`| **Likelihood** | ${sanitizeTableCell(threat.likelihood || "N/A")} |`);
@@ -318,11 +322,15 @@ const downloadXLS = (data, filename) => {
 
   // Get column selections (if provided by export options)
   const exportColumns = data?._exportColumns;
+  const methodology = resolveMethodology(data);
 
   // Column mapping: key → { header, getValue }
   const columnDefs = {
     name: { header: "Name", getValue: (t) => t.name || "" },
-    strideCategory: { header: "STRIDE Category", getValue: (t) => t.stride_category || "" },
+    strideCategory:
+      methodology === "maestro"
+        ? { header: "MAESTRO Layer", getValue: (t) => t.maestro_layer || "" }
+        : { header: "STRIDE Category", getValue: (t) => t.stride_category || "" },
     description: { header: "Description", getValue: (t) => t.description || "" },
     target: { header: "Target", getValue: (t) => t.target || "" },
     likelihood: { header: "Likelihood", getValue: (t) => t.likelihood || "" },
@@ -544,6 +552,8 @@ export const useThreatModelDownload = (response, base64Content) => {
           return;
         }
 
+        const methodology = resolveMethodology(filteredData);
+
         // Generate DOCX and PDF documents with filtered data
         const doc = await createThreatModelingDocument(
           filteredData?.title,
@@ -554,7 +564,8 @@ export const useThreatModelDownload = (response, base64Content) => {
           filteredData?.system_architecture?.data_flows,
           filteredData?.system_architecture?.trust_boundaries,
           filteredData?.system_architecture?.threat_sources,
-          filteredData?.threat_list?.threats
+          filteredData?.threat_list?.threats,
+          methodology
         );
 
         const pdfDoc = await createThreatModelingPDF(
@@ -566,7 +577,8 @@ export const useThreatModelDownload = (response, base64Content) => {
           filteredData?.system_architecture?.data_flows,
           filteredData?.system_architecture?.trust_boundaries,
           filteredData?.system_architecture?.threat_sources,
-          filteredData?.threat_list?.threats
+          filteredData?.threat_list?.threats,
+          methodology
         );
 
         // Download the requested format

--- a/src/components/ThreatModeling/methodologyUtils.js
+++ b/src/components/ThreatModeling/methodologyUtils.js
@@ -1,0 +1,36 @@
+/**
+ * Resolves the threat modeling methodology ("stride" | "maestro") for a threat
+ * model item. Pre-#146 records have no `methodology` field at all, so fall back
+ * to inferring it from which classification field the threats actually carry.
+ */
+export function resolveMethodology(item) {
+  if (item?.methodology === "maestro" || item?.methodology === "stride") {
+    return item.methodology;
+  }
+  const threats = item?.threat_list?.threats || [];
+  if (threats.some((t) => t?.maestro_layer)) {
+    return "maestro";
+  }
+  return "stride";
+}
+
+// Short descriptions for the methodology selector's info popover. Ported/summarized
+// from backend/threat_designer/constants.py's MAESTRO_LAYER_DEFINITIONS.
+export const MAESTRO_LAYER_DESCRIPTIONS = {
+  "Foundation Models":
+    "The pretrained or fine-tuned model performing inference, reasoning, or generation.",
+  "Data Operations":
+    "Pipelines that ingest, embed, store, or retrieve data — training corpora, vector stores, RAG sources, caches.",
+  "Agent Frameworks":
+    "Orchestration that lets a model plan or act — agent loops, tool/function calling, MCP servers, memory.",
+  "Deployment and Infrastructure":
+    "The compute, network, and supply chain the system runs on — containers, gateways, registries, CI/CD.",
+  "Evaluation and Observability":
+    "Monitoring, logging, tracing, evaluation harnesses, guardrails, and drift detection.",
+  "Security and Compliance":
+    "Cross-cutting controls — auth, access control, audit trails, regulatory requirements — applicable regardless of architecture.",
+  "Agent Ecosystem":
+    "Interaction between this system's agents and other agents or external parties — delegation, marketplaces, third-party plugins.",
+  "Cross-Layer":
+    "Threats that span multiple layers rather than living in one, such as supply-chain compromise or goal-misalignment cascades.",
+};

--- a/src/components/ThreatModeling/threatmodel/ThreatModelContent.jsx
+++ b/src/components/ThreatModeling/threatmodel/ThreatModelContent.jsx
@@ -11,6 +11,7 @@ import { VersionModalComponent } from "../VersionModal";
 import DeleteModal from "../DeleteModal";
 import SharingModal from "../SharingModal";
 import { useThreatModelContext } from "../ThreatModelContext";
+import { resolveMethodology } from "../methodologyUtils";
 
 /**
  * ThreatModelContent - Presentational component for rendering the main content area
@@ -80,10 +81,17 @@ const ThreatModelContent = React.memo(
 
     // Memoize the dashboard component to prevent re-rendering when switching views
     const tokenUsage = response?.item?.token_usage || null;
+    const methodology = useMemo(() => resolveMethodology(response?.item), [response?.item]);
     const dashboardComponent = useMemo(() => {
       if (!showDashboard || !results) return null;
-      return <ThreatModelDashboard threatCatalogData={threatCatalogData} tokenUsage={tokenUsage} />;
-    }, [showDashboard, results, threatCatalogData, tokenUsage]);
+      return (
+        <ThreatModelDashboard
+          threatCatalogData={threatCatalogData}
+          tokenUsage={tokenUsage}
+          methodology={methodology}
+        />
+      );
+    }, [showDashboard, results, threatCatalogData, tokenUsage, methodology]);
 
     // Memoize the threat list component to prevent re-rendering when switching views
     const threatListComponent = useMemo(() => {
@@ -102,6 +110,7 @@ const ThreatModelContent = React.memo(
           updateTM={updateThreatModeling}
           refreshTrail={refreshTrail}
           isReadOnly={isReadOnly}
+          methodology={methodology}
         />
       );
     }, [
@@ -113,6 +122,7 @@ const ThreatModelContent = React.memo(
       updateThreatModeling,
       refreshTrail,
       isReadOnly,
+      methodology,
     ]);
 
     return (

--- a/src/components/ThreatModeling/threatmodel/ThreatModelHeader.jsx
+++ b/src/components/ThreatModeling/threatmodel/ThreatModelHeader.jsx
@@ -3,7 +3,9 @@ import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Link from "@cloudscape-design/components/link";
+import Badge from "@cloudscape-design/components/badge";
 import ThreatModelActions from "./ThreatModelActions";
+import { isMaestroEnabled } from "../../../config.js";
 
 /**
  * ThreatModelHeader Component
@@ -23,6 +25,7 @@ import ThreatModelActions from "./ThreatModelActions";
  * @param {Function} props.onActionClick - Callback function when an action is clicked
  * @param {boolean} props.showDashboard - Whether dashboard view is active
  * @param {Function} props.onToggleDashboard - Callback function when dashboard toggle is clicked
+ * @param {string} props.methodology - Threat modeling methodology ("stride" | "maestro")
  * @returns {JSX.Element} The header section with breadcrumbs, title, and actions
  */
 const ThreatModelHeader = React.memo(
@@ -41,6 +44,7 @@ const ThreatModelHeader = React.memo(
     parentId,
     parentTitle,
     onCompare,
+    methodology = "stride",
   }) => {
     return (
       <div data-testid="threat-model-header">
@@ -85,8 +89,13 @@ const ThreatModelHeader = React.memo(
             ) : undefined
           }
         >
-          <SpaceBetween direction="horizontal" size="xs">
+          <SpaceBetween direction="horizontal" size="xs" alignItems="center">
             <div>{title}</div>
+            {isMaestroEnabled() && title && (
+              <Badge color={methodology === "maestro" ? "blue" : "grey"}>
+                {methodology === "maestro" ? "MAESTRO" : "STRIDE"}
+              </Badge>
+            )}
           </SpaceBetween>
         </Header>
       </SpaceBetween>

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ let config = {
   controlPlaneAPI: import.meta.env.VITE_APP_ENDPOINT,
   sentryEnabled: import.meta.env.VITE_SENTRY_ENABLED === "true",
   sentryArn: import.meta.env.VITE_APP_SENTRY || "",
+  maestroEnabled: import.meta.env.VITE_MAESTRO_ENABLED === "true",
 };
 
 const amplifyConfig = {
@@ -25,5 +26,6 @@ const amplifyConfig = {
   },
 };
 export const isSentryEnabled = () => config.sentryEnabled;
+export const isMaestroEnabled = () => config.maestroEnabled;
 
 export { config, amplifyConfig };

--- a/src/services/ThreatDesigner/stats.jsx
+++ b/src/services/ThreatDesigner/stats.jsx
@@ -51,7 +51,8 @@ async function startThreatModeling(
   instructions = null,
   imageType = null,
   applicationType = "hybrid",
-  spaceId = null
+  spaceId = null,
+  methodology = null
 ) {
   const statsPath = "";
   const postData = {
@@ -70,6 +71,9 @@ async function startThreatModeling(
   };
   if (spaceId) {
     postData.space_id = spaceId;
+  }
+  if (methodology) {
+    postData.methodology = methodology;
   }
   return instance.post(statsPath, postData);
 }


### PR DESCRIPTION
Closes the frontend portion of #143. Follow-up to #146, which shipped MAESTRO backend/infra and explicitly deferred the frontend: *"Frontend (methodology selector, `MaestroChart`), CLI, and Sentry are follow-up PRs."*

## Summary

- **Methodology selector** in the submission wizard (`SubmissionForm.jsx`) — STRIDE/MAESTRO, gated behind `VITE_MAESTRO_ENABLED` (hidden entirely when the flag is off, mirroring the backend's hard-reject behavior rather than degrading silently).
- **`MaestroChart`** — horizontal stacked bar chart for the 8 MAESTRO layers, alongside a new `aggregateByMaestroWithLikelihood`, wired into the dashboard as a single methodology-agnostic board item (renamed `"stride-chart"` → `"category-chart"` to avoid the board's `localStorage` layout key colliding across methodologies for different models).
- **Methodology badge** on the threat model header — issue #143 explicitly asked for this ("show methodology as a badge so mixed catalogs stay readable"); every other surface was already methodology-aware except the page header itself.
- Every other place the UI assumed `stride_category` — catalog card display, filters, export options (PDF/DOCX/XLSX/Markdown), and their column/field labels — updated to be methodology-aware, keyed off a single `resolveMethodology()` helper (falls back to inferring from `maestro_layer` presence for pre-#146 records with no `methodology` field).
- `methodology` is threaded into the create-model payload but deliberately **never** sent on replay or version creation — confirmed against the backend (`agent.py`'s `_handle_replay_state`/`_handle_version_state`) that methodology is authoritatively restored from the existing stored item regardless of payload, so omitting it is correct, not an oversight.

## Testing

- `npm run build` and lint clean (zero new errors versus the `main` baseline — this repo has pre-existing lint/prettier debt in a few files this PR touches; verified via stash-diff that none of it is newly introduced).
- **Live end-to-end test against a real AWS deployment**: full stack deployed fresh (Terraform + Bedrock AgentCore + Amplify), logged in, submitted a real threat model with MAESTRO selected, and confirmed a complete MAESTRO-classified catalog renders correctly end-to-end — chart, catalog cards, filters, and the new header badge. (Needed a Bedrock model substitution for testing only, since `claude-opus-4-7` access wasn't available on the test account — same gap #146 flagged; not a code issue.) Stack fully destroyed afterward, no lingering AWS resources.
- Security review: no findings — `maestro_layer` flows through the same sanitized export/render sinks `stride_category` already used; no new injection surface.
- Code review surfaced one real bug (Sentry AI session-context distribution bucketing MAESTRO threats under `undefined`), fixed in this branch; two other flagged concerns were verified as false positives against the actual backend replay logic and an unrelated table component.

## Scope

Frontend only, matching #146's explicit deferral. CLI (`--methodology` flag) and Sentry backend (`data_model.py`/`prompt.py`) are separate follow-ups per the original issue's scope table — Sentry's inert MAESTRO tool-gating already landed as part of #146 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwF9yysnSiPYCvC7hYzJQU