### PR TITLE
Overall improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Threat Designer supports two AI providers. Choose one based on your preference:
 
 You must enable access to the following models in your AWS region:
 
-- **Claude 4.6 Opus**
-- **Claude 4.5 Sonnet**
-- **Claude 4.5 Haiku**
+- **Claude Opus 5**
+- **Claude Sonnet 5**
+- **Claude Haiku 4.5**
 
 To enable Claude models, follow the instructions [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html). Make sure you are already subscribed to the models otherwise you will receive an `AccessDeniedException` exception whe using the application.
 
@@ -144,9 +144,15 @@ To enable Claude models, follow the instructions [here](https://docs.aws.amazon.
 You'll need:
 
 - A valid OpenAI API key
-- Access to GPT-5.4 or GPT-5 Mini models
+- Access to the GPT-5.6 family models (Sol, Terra, Luna)
 
 You'll be prompted to enter your API key during deployment.
+
+#### Option 3: Amazon Bedrock Mantle (GPT models on Bedrock)
+
+The same GPT-5.6 family models served through the Bedrock Mantle OpenAI-compatible endpoint — no OpenAI API key required. Authentication uses SigV4-derived bearer tokens minted from the agent's IAM role.
+
+> **Warning:** GPT-5.x on Bedrock Mantle is only served from US regions. Model inference is locked to `us-east-2` (configurable to `us-west-2` via the `mantle_region` Terraform variable), regardless of the region you deploy the application to.
 
 ### Installation and Deployment
 
@@ -184,10 +190,11 @@ export AWS_PROFILE="your_profile_name"
 
 During deployment, you'll be prompted to:
 
-- Select your AI model provider (Amazon Bedrock or OpenAI)
+- Select your AI model provider (Amazon Bedrock, OpenAI, or Bedrock Mantle)
 - Enter your OpenAI API key (if using OpenAI)
 - Provide a valid email address for user credentials
 - Choose whether to enable Sentry AI Assistant
+- Select a web search provider for Sentry (none, Tavily, or Amazon Bedrock AgentCore)
 
 > **Note:** A user will be created in Amazon Cognito User Pool and temporary credentials will be sent to the configured email address.
 
@@ -205,46 +212,67 @@ Application Login page: https://dev.xxxxxxxxxxxxxxxx.amplifyapp.com
 
 ### AI Model Provider Selection
 
-Threat Designer supports two AI providers that can be selected during deployment:
+Threat Designer supports three AI provider options that can be selected during deployment:
 
 ```
 Select AI model provider:
 1) Amazon Bedrock (Claude) (default)
-2) OpenAI (GPT-5.4)
+2) OpenAI (GPT-5.6)
+3) Amazon Bedrock Mantle (GPT-5.6, no OpenAI API key needed)
 ```
 
 #### Amazon Bedrock Configuration (default model)
 
 **Used Models:**
 
-- **Claude 4.X family models**
+- **Claude Opus 5** — main threat modeling workflow
+- **Claude Sonnet 5** — Sentry assistant and structured output
+- **Claude Haiku 4.5** — summaries
 
 **Key Characteristics:**
 
-- **Reasoning**: Hybrid model
-- **Reasoning Levels**: None, Low, Medium, High, Max (maps to different reasoning token budgets or adaptive effort levels)
+- **Reasoning**: Adaptive thinking (Claude 5 family)
+- **Reasoning Levels**: Low, Medium, High, Extra High (maps to adaptive effort levels; token budgets remain only for pre-4.6 models)
 
-> **Note:** Models listed in the `adaptive_thinking_models` Terraform variable (e.g., Claude Opus 4.6) use adaptive thinking with effort levels (`low`, `medium`, `high`, `max`) instead of token budgets. For these models, the `reasoning_budget` configuration is ignored — the reasoning level from the UI is mapped directly to an effort string. Standard models continue to use token-budget-based reasoning as before.
+> **Note:** Models listed in the `adaptive_thinking_models` Terraform variable (e.g., Claude Opus 5, Claude Sonnet 5) use adaptive thinking with effort levels instead of token budgets. For these models, the `reasoning_budget` configuration is ignored — the reasoning level from the UI is mapped directly to an effort string. Pre-4.6 models continue to use token-budget-based reasoning as before.
 >
-> **Note:** Claude Opus 4.6 supports a maximum output of 128K tokens, while other Claude 4.x family models support up to 64K tokens. If switching between models, make sure to update the `max_tokens` configuration accordingly to avoid API errors.
+> **Note:** The highest selectable level (Extra High) maps to `xhigh`, the recommended effort for demanding coding and agentic work. The models also support `max` above it, but it costs substantially more for marginal gains — opt in per stage by setting `"4" = "max"` in that stage's `effort_map` in `infra/variables.tf`.
+>
+> **Note:** There is no "off" reasoning level. Every current model is a reasoning model, and on Claude Opus 5 thinking is on by default and cannot be disabled above effort `high` — omitting the thinking config does not turn it off, it just runs adaptive thinking at the provider's default effort. An "off" level therefore billed for thinking while discarding the reasoning output, so the ladder starts at Low. Levels are `1`–`4`; a legacy `0` from an older client is accepted and normalized to `1`.
+>
+> **Note:** Claude 5 family models support a maximum output of 128K tokens, while older Claude 4.x models may support less. If switching between models, make sure to update the `max_tokens` configuration accordingly to avoid API errors.
 
 #### OpenAI Configuration
 
 **Used Models:**
 
-- **GPT-5 Mini** (default) - Faster and more cost-effective
-- **GPT-5.4** - Maximum reasoning capability
+- **GPT-5.6 Sol** — main threat modeling workflow (flagship capability; the `gpt-5.6` alias routes to it)
+- **GPT-5.6 Terra** — Sentry assistant and structured output (strong performance at lower price)
+- **GPT-5.6 Luna** — summaries (efficient, high-volume workloads)
 
 **Key Characteristics:**
 
-- **Reasoning**: Always enabled (built-in capability that cannot be disabled)
-- **Reasoning Levels**: Low, Medium, High (maps to OpenAI's reasoning effort)
+- **Reasoning**: Reasoning models on the Responses API
+- **Reasoning Levels**: Low, Medium, High, Extra High (maps to OpenAI's `reasoning_effort`: `low`, `medium`, `high`, `xhigh`). GPT-5.6 also supports `max` above `xhigh` — opt in via `reasoning_effort` in `infra/variables.tf` — and no longer accepts `minimal`.
 
 **To use OpenAI:**
 
 1. Select option `2` when prompted for model provider during deployment
 2. Enter your OpenAI API key when prompted
 3. The system will configure both Threat Designer and Sentry to use OpenAI
+
+#### Amazon Bedrock Mantle Configuration
+
+Runs the same GPT-5.6 models (and prompts) as the OpenAI option, but served by the Bedrock Mantle OpenAI-compatible endpoint:
+
+- **No OpenAI API key** — auth is a SigV4-derived bearer token minted from the agent's IAM role (`bedrock-mantle:*` permissions are granted automatically at deploy time)
+- **US-locked inference** — Mantle serves GPT-5.x only from `us-east-2` / `us-west-2`; the deployment shows a warning and defaults to `us-east-2` (override with the `mantle_region` Terraform variable)
+- Model IDs are automatically prefixed with `openai.` (e.g., `openai.gpt-5.6-sol`) as Mantle requires
+
+**To use Bedrock Mantle:**
+
+1. Select option `3` when prompted for model provider during deployment
+2. The system will configure both Threat Designer and Sentry to use GPT-5.6 via Mantle
 
 #### Switching Between Providers
 
@@ -257,19 +285,32 @@ To switch between Amazon Bedrock and OpenAI:
 
 ### Web Search Integration (Optional Feature)
 
-Sentry can perform real-time web searches to research CVEs, vulnerabilities, and security topics using [Tavily](https://tavily.com/). This feature is **optional** and requires a Tavily API key.
+Sentry can perform real-time web searches to research CVEs, vulnerabilities, and security topics. This feature is **optional**, and you choose the provider at deployment time.
 
 #### Enabling Web Search
 
 During deployment, you will be prompted:
 
 ```
-Enter your Tavily API key (optional, press Enter to skip):
-(Enables web search and content extraction in Sentry assistant)
+Select web search provider for Sentry:
+1) None (default)
+2) Tavily (search + page extraction, requires an API key)
+3) Amazon Bedrock AgentCore (search only, no API key needed)
 ```
 
-- **With API key**: Sentry gains access to `tavily_search` and `tavily_extract` tools for real-time security research
-- **Without API key**: Sentry works normally but cannot perform web searches
+| Provider          | Tools Sentry gains                 | Credentials                                 |
+| ----------------- | ---------------------------------- | ------------------------------------------- |
+| None              | —                                  | —                                           |
+| Tavily            | `tavily_search` + `tavily_extract` | Tavily API key                              |
+| Bedrock AgentCore | `web_search` only                  | None — SigV4 from the Sentry execution role |
+
+> **Note:** The AgentCore connector offers **search only** — there is no page-extraction counterpart. When it is selected the extract tool is simply absent, and Sentry's prompt is adjusted so it works from result snippets and does not offer to read a page in depth. Choose Tavily if you need full page content.
+
+#### Amazon Bedrock AgentCore
+
+AgentCore's web search is reachable only as a built-in connector target on an AgentCore **Gateway** (there is no direct search API), so selecting it provisions a gateway with `AWS_IAM` inbound auth plus its service role, and Sentry calls it over MCP signed with SigV4 from its own execution role. No API key is stored anywhere.
+
+> **Warning:** The connector is only offered in `us-east-1`, `eu-west-1`, and `ap-northeast-1`. The gateway is created in `web_search_region` (default `us-east-1`), which may differ from your deployment region — queries are served inside AWS but can leave the deployment's region. Tune result volume with the `web_search_max_results` Terraform variable (1–25, default 5).
 
 #### Getting a Tavily API Key
 
@@ -346,7 +387,7 @@ MAESTRO is enabled by default. To disable it, update the `.deployment.config` fi
 ENABLE_MAESTRO=false
 ```
 
-When disabled, the API rejects *new* requests that ask for MAESTRO rather than silently falling back to STRIDE. Replaying or versioning an existing MAESTRO model is unaffected by the flag — its methodology is fixed at creation and is loaded from the stored record either way, so disabling MAESTRO doesn't strand catalogs created while it was on. STRIDE threat modeling is unaffected either way.
+When disabled, the API rejects _new_ requests that ask for MAESTRO rather than silently falling back to STRIDE. Replaying or versioning an existing MAESTRO model is unaffected by the flag — its methodology is fixed at creation and is loaded from the stored record either way, so disabling MAESTRO doesn't strand catalogs created while it was on. STRIDE threat modeling is unaffected either way.
 
 ---
 

--- a/backend/app/routes/attack_tree_route.py
+++ b/backend/app/routes/attack_tree_route.py
@@ -45,8 +45,14 @@ def create_attack_tree():
             "threat_model_id": "uuid",
             "threat_name": "string",
             "threat_description": "string",
-            "reasoning": 0-3 (optional)
+            "reasoning": 1-4 (optional, accepted but not applied — see below)
         }
+
+    Note on "reasoning": attack tree generation pins its own effort level
+    (ATTACK_TREE_REASONING_LEVEL in the agent) so the tree is built at a
+    consistent depth regardless of the caller. The field is still accepted and
+    validated so existing clients keep working, but it does not change the
+    effort used.
 
     Returns:
         {
@@ -73,7 +79,7 @@ def create_attack_tree():
         threat_model_id = body.get("threat_model_id")
         threat_name = body.get("threat_name")
         threat_description = body.get("threat_description")
-        reasoning = body.get("reasoning", 0)
+        reasoning = body.get("reasoning", 1)
 
         if not threat_model_id:
             raise BadRequestError("threat_model_id is required")
@@ -84,9 +90,12 @@ def create_attack_tree():
         if not threat_description:
             raise BadRequestError("threat_description is required")
 
-        # Validate reasoning level
-        if not isinstance(reasoning, int) or reasoning < 0 or reasoning > 3:
-            raise BadRequestError("reasoning must be an integer between 0 and 3")
+        # Validate reasoning level. Levels run 1-4; 0 is still accepted from
+        # older clients and normalized to the minimum by the agent. Validated
+        # even though the agent pins its own attack-tree level, so a malformed
+        # value is still rejected rather than silently swallowed.
+        if not isinstance(reasoning, int) or reasoning < 0 or reasoning > 4:
+            raise BadRequestError("reasoning must be an integer between 1 and 4")
 
         # Invoke attack tree agent
         result = invoke_attack_tree_agent(

--- a/backend/app/services/threat_designer_service.py
+++ b/backend/app/services/threat_designer_service.py
@@ -268,7 +268,9 @@ def invoke_lambda(owner, payload):
     if not s3_locations and s3_location:
         s3_locations = [s3_location]
     iteration = payload.get("iteration")
-    reasoning = payload.get("reasoning", 0)
+    # Reasoning levels run 1-4; there is no "off" level. The agent normalizes a
+    # legacy 0 from an older client up to the minimum.
+    reasoning = payload.get("reasoning", 1)
     instructions = payload.get("instructions", None)
     is_replay = payload.get("replay", False)
     is_version = payload.get("version", False)

--- a/backend/dependencies/requirements-langchain.txt
+++ b/backend/dependencies/requirements-langchain.txt
@@ -1,4 +1,4 @@
-langchain-aws==1.3.0
+langchain-aws==1.6.4
 langchain-task-steering>=0.1.6
 langgraph==1.0.10
 structlog==25.4.0

--- a/backend/sentry/agent.py
+++ b/backend/sentry/agent.py
@@ -11,9 +11,15 @@ from handlers import handlers
 from streaming import streaming_handler, cancel_stream_async
 from exceptions import MissingHeader
 from utils import logger, load_mcp_config
-from config import ALL_AVAILABLE_TOOLS
+from config import (
+    ALL_AVAILABLE_TOOLS,
+    WEB_SEARCH_PROVIDER,
+    WEB_SEARCH_PROVIDER_AGENTCORE,
+    WEB_SEARCH_PROVIDER_TAVILY,
+)
 from tools import add_threats, edit_threats, delete_threats, get_attack_tree
 from tavily_tools import get_tavily_tools
+from web_search_tools import get_agentcore_web_search_tools
 import jwt
 
 
@@ -61,14 +67,22 @@ async def lifespan(app: FastAPI):
         ALL_AVAILABLE_TOOLS.clear()
         ALL_AVAILABLE_TOOLS.extend(filtered_mcp_tools)
 
-        # Load Tavily tools if configured
-        tavily_tools = get_tavily_tools()
+        # Load web search tools for the provider chosen at deploy time. Tavily
+        # contributes search + extract; AgentCore contributes search only (its
+        # connector has no fetch counterpart).
+        if WEB_SEARCH_PROVIDER == WEB_SEARCH_PROVIDER_TAVILY:
+            web_search_tools = get_tavily_tools()
+        elif WEB_SEARCH_PROVIDER == WEB_SEARCH_PROVIDER_AGENTCORE:
+            web_search_tools = get_agentcore_web_search_tools()
+        else:
+            web_search_tools = []
 
-        if tavily_tools:
+        if web_search_tools:
             logger.debug(
-                f"Loaded {len(tavily_tools)} Tavily tools: {[t.name for t in tavily_tools]}"
+                f"Loaded {len(web_search_tools)} web search tool(s) from "
+                f"{WEB_SEARCH_PROVIDER}: {[t.name for t in web_search_tools]}"
             )
-            ALL_AVAILABLE_TOOLS.extend(tavily_tools)
+            ALL_AVAILABLE_TOOLS.extend(web_search_tools)
 
         ALL_AVAILABLE_TOOLS.extend(
             [add_threats, edit_threats, delete_threats, get_attack_tree]

--- a/backend/sentry/agent_manager.py
+++ b/backend/sentry/agent_manager.py
@@ -6,6 +6,7 @@ from config import (
     S3_BUCKET,
     create_model,
 )
+from config import MIN_BUDGET_LEVEL, normalize_budget_level
 from utils import get_or_create_agent, logger
 
 
@@ -21,15 +22,22 @@ class AgentManager:
         self.current_diagram_path = None
         self.current_diagram_hash = None
         self.current_diagram_data = None
-        self.current_budget_level = 0
+        # Start at the ladder floor, not 0. A 0 here is not a reachable budget
+        # level any more, so it would never match the first incoming level and
+        # would rebuild the agent and LLM once for nothing.
+        self.current_budget_level = MIN_BUDGET_LEVEL
 
     async def get_agent_with_preferences(
         self,
         tool_preferences: Optional[List[str]],
         context: Optional[Dict[str, Any]] = None,
         diagram_path: Optional[str] = None,
-        budget_level: int = 0,
+        budget_level: int = MIN_BUDGET_LEVEL,
     ):
+        # Clamp before comparing, so a legacy 0 from an older client resolves to
+        # the same level create_model would build and does not force a rebuild.
+        budget_level = normalize_budget_level(budget_level)
+
         # Check if budget level changed - if so, we need to recreate the agent and LLM
         budget_level_changed = self.current_budget_level != budget_level
         if budget_level_changed:

--- a/backend/sentry/config.py
+++ b/backend/sentry/config.py
@@ -1,5 +1,7 @@
 import os
 import json
+import threading
+import time
 from langgraph_checkpoint_aws.async_saver import AsyncBedrockSessionSaver
 from langgraph_checkpoint_aws.saver import BedrockSessionSaver
 from botocore.session import get_session
@@ -24,14 +26,57 @@ MODEL_PROVIDER = os.environ.get("MODEL_PROVIDER", "bedrock")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 MAX_TOKENS = int(os.environ.get("MAX_TOKENS", "64000"))
 
+# Bedrock Mantle: GPT models served through the Bedrock OpenAI-compatible
+# endpoint — same models/prompts as the "openai" provider, SigV4 bearer-token
+# auth instead of an API key. GPT-5.x on Mantle is US-regions only
+# (us-east-2 / us-west-2), independent of the deployment region.
+MODEL_PROVIDER_BEDROCK_MANTLE = "bedrock-mantle"
+OPENAI_FAMILY_PROVIDERS = ("openai", MODEL_PROVIDER_BEDROCK_MANTLE)
+# Message-format family — streaming.py compares this against the format
+# detected in a resumed session, so Mantle must read as "openai" there.
+PROVIDER_MESSAGE_FAMILY = (
+    "openai" if MODEL_PROVIDER in OPENAI_FAMILY_PROVIDERS else "bedrock"
+)
+MANTLE_REGION = os.environ.get("MANTLE_REGION", "us-east-2")
+# Mantle GPT model IDs carry an "openai." prefix (e.g. "openai.gpt-5.6-terra").
+MANTLE_MODEL_PREFIX = "openai."
+# Re-mint the SigV4-presigned bearer token well inside the ~1h life of the
+# runtime role credentials that sign it.
+MANTLE_TOKEN_TTL_SECONDS = 1800
+
+# Budget (reasoning) levels run 1-4 with no "off" level — every current model is
+# a reasoning model, and on Claude Opus 5 thinking cannot be disabled above
+# effort "high". A legacy 0 from an older client clamps up to the minimum.
+MIN_BUDGET_LEVEL = 1
+MAX_BUDGET_LEVEL = 4
+
+
+def normalize_budget_level(value) -> int:
+    """Coerce an incoming budget level onto the supported 1-4 ladder."""
+    try:
+        level = int(value)
+    except (TypeError, ValueError):
+        return MIN_BUDGET_LEVEL
+    return min(max(level, MIN_BUDGET_LEVEL), MAX_BUDGET_LEVEL)
+
+# Web search provider, chosen at deploy time. "tavily" gives search + extract;
+# "agentcore" gives search ONLY (the Bedrock AgentCore connector has no fetch
+# counterpart), so the extract tool is simply absent. "none" disables web search.
+WEB_SEARCH_PROVIDER_NONE = "none"
+WEB_SEARCH_PROVIDER_TAVILY = "tavily"
+WEB_SEARCH_PROVIDER_AGENTCORE = "agentcore"
+WEB_SEARCH_PROVIDER = os.environ.get(
+    "WEB_SEARCH_PROVIDER", WEB_SEARCH_PROVIDER_NONE
+).strip().lower()
+
 # Tavily Configuration
 TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY")
 
 
 # Parse reasoning budget/effort from environment
 def _parse_reasoning_config() -> dict:
-    """Parse reasoning budget (Bedrock) or effort (OpenAI) from environment"""
-    if MODEL_PROVIDER == "openai":
+    """Parse reasoning budget (Bedrock) or effort (OpenAI/Mantle) from environment"""
+    if MODEL_PROVIDER in OPENAI_FAMILY_PROVIDERS:
         raw = os.environ.get(
             "REASONING_EFFORT",
             '{"0": "none", "1": "low", "2": "medium", "3": "high", "4": "xhigh"}',
@@ -46,7 +91,10 @@ REASONING_CONFIG = _parse_reasoning_config()
 
 # Adaptive thinking configuration
 ADAPTIVE_THINKING_MODELS = json.loads(os.environ.get("ADAPTIVE_THINKING_MODELS", "[]"))
-ADAPTIVE_EFFORT_MAP = {1: "low", 2: "medium", 3: "high", 4: "max"}
+# Level 4 tops out at "xhigh" — the recommended setting for demanding agentic
+# work; "max" costs substantially more for marginal gains. A per-model
+# EFFORT_MAP can still opt into "max".
+ADAPTIVE_EFFORT_MAP = {1: "low", 2: "medium", 3: "high", 4: "xhigh"}
 
 
 def _normalize_model_id(model_id: str) -> str:
@@ -67,7 +115,8 @@ def _is_adaptive_model(model_id: str | None) -> bool:
 _raw_effort_map = os.environ.get("EFFORT_MAP")
 EFFORT_MAP = json.loads(_raw_effort_map) if _raw_effort_map else None
 
-# OpenAI reasoning effort mapping (fallback for backward compatibility)
+# OpenAI reasoning effort mapping (fallback for backward compatibility).
+# GPT-5.6 rejects "minimal"; level 4 tops out at "xhigh" (see above).
 OPENAI_REASONING_EFFORT_MAP = {0: "none", 1: "low", 2: "medium", 3: "high", 4: "xhigh"}
 
 
@@ -106,9 +155,10 @@ BUDGET_MAPPING = (
 )
 
 
-def create_model_config(budget_level: int = 1) -> dict:
+def create_model_config(budget_level: int = MIN_BUDGET_LEVEL) -> dict:
     """Create model configuration based on budget level and provider"""
-    if MODEL_PROVIDER == "openai":
+    budget_level = normalize_budget_level(budget_level)
+    if MODEL_PROVIDER in OPENAI_FAMILY_PROVIDERS:
         return _create_openai_model_config(budget_level)
     else:
         return _create_bedrock_model_config(budget_level)
@@ -118,19 +168,14 @@ def _create_bedrock_model_config(budget_level: int = 1) -> dict:
     """Create Bedrock model configuration based on budget level"""
     is_adaptive = _is_adaptive_model(MODEL_ID)
 
+    # No temperature: Claude 4.6+ (incl. Sonnet 5 / Opus 5) removed the sampling
+    # parameters and reject them, and pre-4.6 models default to 1.0 — the only
+    # value they accept while thinking is enabled.
     base_config = {
         "max_tokens": MAX_TOKENS,
         "model_id": MODEL_ID,
         "client": boto_client,
     }
-
-    # Adaptive models (e.g. Opus 4.7) don't support the temperature parameter
-    if not is_adaptive:
-        base_config["temperature"] = 0 if budget_level == 0 else 1
-
-    # If budget_level is 0, don't add thinking at all
-    if budget_level == 0:
-        return base_config
 
     # Check if the model supports adaptive thinking
     if is_adaptive:
@@ -158,39 +203,96 @@ def _create_bedrock_model_config(budget_level: int = 1) -> dict:
     return base_config
 
 
+# One token cache per region, shared across every model this process builds —
+# create_model is re-run whenever the budget level changes, so a cache per
+# closure would re-mint from scratch each time. Locked because tool calls and
+# model invocations run on worker threads. Mirrors the same helper in the
+# threat_designer container, which ships as a separate image.
+_MANTLE_TOKEN_CACHES: dict = {}
+_MANTLE_TOKEN_LOCK = threading.Lock()
+
+
+def _mantle_token_provider(region: str):
+    """A callable returning a fresh Bedrock Mantle bearer token, cached briefly.
+
+    langchain_openai accepts ``api_key`` as a callable and invokes it per
+    request, so long sessions keep re-reading a currently-valid token minted
+    from whatever role credentials the default chain currently holds.
+    """
+    from aws_bedrock_token_generator import provide_token
+
+    with _MANTLE_TOKEN_LOCK:
+        cache = _MANTLE_TOKEN_CACHES.setdefault(region, {"token": None, "exp": 0.0})
+
+    def _provider() -> str:
+        with _MANTLE_TOKEN_LOCK:
+            now = time.time()
+            if cache["token"] is None or now >= cache["exp"]:
+                cache["token"] = provide_token(region=region)
+                cache["exp"] = now + MANTLE_TOKEN_TTL_SECONDS
+            return cache["token"]
+
+    return _provider
+
+
 def _create_openai_model_config(budget_level: int = 1) -> dict:
-    """Create OpenAI model configuration based on budget level"""
+    """Create GPT model configuration (direct OpenAI or Bedrock Mantle)"""
     if not OPENAI_AVAILABLE:
         raise ImportError(
             "OpenAI provider requires langchain-openai package. "
             "Install with: pip install langchain-openai"
         )
 
-    if not OPENAI_API_KEY:
-        raise ValueError("OPENAI_API_KEY environment variable not set")
+    use_mantle = MODEL_PROVIDER == MODEL_PROVIDER_BEDROCK_MANTLE
 
+    # No temperature: the whole GPT-5 family rejects the parameter outright
+    # ("Unsupported parameter: 'temperature' is not supported with this model",
+    # HTTP 400), including calls made with no reasoning config.
     base_config = {
-        "model": MODEL_ID or "gpt-5-mini-2025-08-07",
+        "model": MODEL_ID or "gpt-5.6-terra",
         "max_tokens": MAX_TOKENS,
-        "api_key": OPENAI_API_KEY,
-        "temperature": 0,
         "use_responses_api": True,
         "streaming": True,
     }
 
-    # Add reasoning effort if budget level > 0
-    if budget_level > 0:
-        reasoning_effort = REASONING_CONFIG.get(budget_level, "low")
+    if use_mantle:
+        if not base_config["model"].startswith(MANTLE_MODEL_PREFIX):
+            base_config["model"] = f"{MANTLE_MODEL_PREFIX}{base_config['model']}"
+        base_config["base_url"] = (
+            f"https://bedrock-mantle.{MANTLE_REGION}.api.aws/openai/v1"
+        )
+        # Bearer token minted from the runtime role's credentials — no API key.
+        base_config["api_key"] = _mantle_token_provider(MANTLE_REGION)
+    else:
+        if not OPENAI_API_KEY:
+            raise ValueError("OPENAI_API_KEY environment variable not set")
+        base_config["api_key"] = OPENAI_API_KEY
+
+    # Always configured: budget levels start at 1, so reasoning is never off.
+    reasoning_effort = REASONING_CONFIG.get(budget_level, "low")
+    if reasoning_effort:
         base_config["reasoning"] = {"effort": reasoning_effort, "summary": "detailed"}
+        # output_version is what puts the reasoning summary into the streamed
+        # message content ({"type": "reasoning", "summary": [...]}) — without it
+        # the summary lands in additional_kwargs and the UI shows no thinking.
+        # Both GPT transports stream through the same ChatOpenAI Responses API,
+        # so gating this on Mantle hid reasoning on direct-OpenAI deploys.
+        base_config["output_version"] = "responses/v1"
 
     return base_config
 
 
-def create_model(budget_level: int = 1) -> Any:
-    """Create model instance based on provider"""
+def create_model(budget_level: int = MIN_BUDGET_LEVEL) -> Any:
+    """Create model instance based on provider.
+
+    The branch must match create_model_config's: "bedrock-mantle" is served by
+    ChatOpenAI (it is the Bedrock OpenAI-compatible endpoint), so testing for
+    "openai" alone would hand a GPT config — including a callable api_key — to
+    ChatBedrockConverse.
+    """
     config = create_model_config(budget_level)
 
-    if MODEL_PROVIDER == "openai":
+    if MODEL_PROVIDER in OPENAI_FAMILY_PROVIDERS:
         return ChatOpenAI(**config)
     else:
         from langchain_aws import ChatBedrockConverse

--- a/backend/sentry/handlers.py
+++ b/backend/sentry/handlers.py
@@ -113,16 +113,15 @@ class RequestHandlers:
             if diagram_path:
                 logger.debug(f"Updating diagram path: {diagram_path}")
 
-            # Log budget level information
-            if budget_level == 0:
-                logger.debug("Budget level 0: Thinking disabled")
-            else:
-                from config import BUDGET_MAPPING
+            # Log budget level information. Thinking is always on: the ladder
+            # starts at 1 and every current model is a reasoning model.
+            from config import BUDGET_MAPPING, normalize_budget_level
 
-                budget_tokens = BUDGET_MAPPING.get(budget_level, 8000)
-                logger.debug(
-                    f"Budget level {budget_level}: Thinking enabled with {budget_tokens} tokens"
-                )
+            budget_level = normalize_budget_level(budget_level)
+            budget_tokens = BUDGET_MAPPING.get(budget_level, 8000)
+            logger.debug(
+                f"Budget level {budget_level}: Thinking enabled with {budget_tokens} tokens"
+            )
 
             await agent_manager.get_agent_with_preferences(
                 tool_preferences, context, diagram_path, budget_level
@@ -137,7 +136,7 @@ class RequestHandlers:
                     "context_loaded": context is not None,
                     "diagram_loaded": agent_manager.current_diagram_data is not None,
                     "budget_level": agent_manager.current_budget_level,
-                    "thinking_enabled": agent_manager.current_budget_level > 0,
+                    "thinking_enabled": True,
                 },
                 headers={
                     "Access-Control-Allow-Origin": "*",

--- a/backend/sentry/prompt.py
+++ b/backend/sentry/prompt.py
@@ -84,7 +84,7 @@ Use self-closing XML tags: `<chart config="{JSON_CONFIG}" />`
 3. Use descriptive titles and labels
 4. Ensure numeric values are valid numbers
 5. Place charts on their own line, not inline with text
-6. Line chart works only with numerical, series data as intigers.  It doesn't work with categorical data and string values.
+6. Line charts work only with numerical series data (integers). They don't work with categorical data or string values.
 
 **Example:**
 To show STRIDE category distribution:
@@ -98,7 +98,7 @@ To show likelihood distribution as donut:
 # Citation instructions prompt - included only when Tavily tools are enabled
 citation_prompt = """
 <citation_instructions>
-If Sentry's response is based on content returned by the tavily_search or tavily_extract tools, Sentry must always appropriately cite its response using XML-style citation tags.
+If Sentry's response is based on content returned by a web search or page extraction tool, Sentry must always appropriately cite its response using XML-style citation tags.
 
 **Citation Format:**
 Use self-closing XML tags: `<cite ref="X:Y" />`
@@ -163,13 +163,30 @@ Default to answering from existing knowledge. Only search when you genuinely can
 - Use 1-2 searches for simple factual verification
 - Use 3-5 searches for comprehensive security research or threat analysis
 - Don't mention knowledge cutoffs or lack of real-time data to the user
+</web_search_behaviors>
+"""
 
+# Appended only when a page-extraction tool is present. The AgentCore web search
+# connector returns snippets and has no fetch counterpart, so this guidance is
+# omitted for that provider rather than describing a capability the agent lacks.
+bedrock_web_fetch_prompt = """
+<web_fetch_behaviors>
 **GitHub URL handling:**
 When extracting content from GitHub file URLs, convert them to raw format first:
 - Replace `github.com` with `raw.githubusercontent.com`
 - Remove `/blob` from the path
 - Example: `https://github.com/{owner}/{repo}/blob/{branch}/{path}` -> `https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}`
-</web_search_behaviors>
+</web_fetch_behaviors>
+"""
+
+# Stated when search is available but extraction is not, so the agent doesn't
+# offer the user a deeper read it cannot perform.
+snippets_only_prompt = """
+<web_search_limits>
+Search returns ranked SNIPPETS only — there is no tool to fetch full page content.
+Do not offer to read a page in depth or promise detail beyond the snippet. When a
+snippet is insufficient, say so and cite what you have, or refine the query.
+</web_search_limits>
 """
 
 
@@ -344,7 +361,9 @@ Act as a trusted security advisor: every recommendation should enhance the organ
 
 
 # ==============================================================================
-# OPENAI (GPT-5.2) PROMPTS — Optimized for GPT-5.2 patterns
+# OPENAI (GPT-5.6) PROMPTS — Optimized for GPT-5.6 patterns: leaner prompts
+# perform better on this family, so each instruction is stated once and
+# self-check scaffolding written for older models is omitted.
 # ==============================================================================
 
 openai_web_search_prompt = """
@@ -377,13 +396,20 @@ DO search for:
 - Never mention knowledge cutoffs or lack of real-time data to the user
 </search_guidelines>
 
+</web_search_behaviors>
+"""
+
+# Appended only when a page-extraction tool is present — see
+# bedrock_web_fetch_prompt.
+openai_web_fetch_prompt = """
+<web_fetch_behaviors>
 <github_url_handling>
 When extracting content from GitHub file URLs, convert to raw format first:
 - Replace `github.com` with `raw.githubusercontent.com`
 - Remove `/blob` from the path
 - Example: `https://github.com/{owner}/{repo}/blob/{branch}/{path}` → `https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}`
 </github_url_handling>
-</web_search_behaviors>
+</web_fetch_behaviors>
 """
 
 
@@ -438,14 +464,6 @@ Redirect or decline: non-security domains, personal advice, medical or legal cou
 - After any write/mutation tool call, restate: what changed, where (threat ID/name), any follow-up needed.
 - When uncertain about dependencies between calls, default to sequential.
 </tool_calling_rules>
-
-<high_risk_self_check>
-Before finalizing threat assessments, gap analyses, or compliance-related recommendations:
-- Re-scan for: unstated assumptions, ungrounded claims, architecturally impossible attack paths, violations of validation gates.
-- Verify all threat actors are present in the data_flow's threat_sources.
-- Confirm mitigations are within customer control boundaries.
-- If any issue is found, correct it before responding.
-</high_risk_self_check>
 
 <uncertainty_handling>
 - If the user's request is ambiguous or underspecified: ask 1 precise clarifying question, OR state your interpretation and proceed with it.
@@ -544,7 +562,6 @@ Reject and exclude any threat with: assumption violations, actors not in threat_
 - A request for mitigation ≠ rewritten threat description.
 - Do not generate supplementary analysis, additional threats, or expanded scope unless explicitly asked.
 - Prefer fewer high-quality threats over comprehensive enumeration.
-- Implement EXACTLY and ONLY what the user requests. No extra features, no added analysis, no unsolicited expansion.
 </scope_discipline>
 </threat_modeling_methodology>
 """
@@ -568,7 +585,6 @@ The threat model context below is dynamic and reflects the current state, update
 When the active context is large (many data flows, threats, or complex architectures):
 - Anchor claims to specific elements ("In the Auth Service data flow…", "For the Customer Database asset…") rather than making generic statements.
 - If an answer depends on fine details (criticality levels, specific threat sources, assumption wording), reference them explicitly.
-- When assessing gaps across the full model, produce a brief internal outline of key areas before responding.
 </long_context_handling>
 {_maestro_tool_note(context)}"""
 
@@ -578,7 +594,7 @@ When the active context is large (many data flows, threats, or complex architect
 # ==============================================================================
 
 
-def system_prompt(context, tavily_enabled=False):
+def system_prompt(context, web_search_enabled=False, web_fetch_enabled=False):
     """
     Generate the system prompt for Sentry.
 
@@ -587,20 +603,27 @@ def system_prompt(context, tavily_enabled=False):
 
     Args:
         context: The threat modeling context
-        tavily_enabled: Whether Tavily tools are available
+        web_search_enabled: Whether a web search tool is available (Tavily or
+            the AgentCore connector)
+        web_fetch_enabled: Whether a page-extraction tool is available. Only
+            Tavily provides one — the AgentCore connector is search-only — so
+            the fetch guidance is omitted rather than describing a capability
+            the agent does not have.
 
     Returns:
         SystemMessage with provider-optimized instructions
     """
     current_date = datetime.now().strftime("%B %d, %Y")
 
-    if MODEL_PROVIDER == "openai":
-        return _build_openai_prompt(current_date, context, tavily_enabled)
+    # GPT prompts apply to both GPT transports — direct OpenAI and Bedrock Mantle.
+    if MODEL_PROVIDER in ("openai", "bedrock-mantle"):
+        builder = _build_openai_prompt
     else:
-        return _build_bedrock_prompt(current_date, context, tavily_enabled)
+        builder = _build_bedrock_prompt
+    return builder(current_date, context, web_search_enabled, web_fetch_enabled)
 
 
-def _build_bedrock_prompt(current_date, context, tavily_enabled):
+def _build_bedrock_prompt(current_date, context, web_search_enabled, web_fetch_enabled):
     """Build system prompt optimized for Bedrock (Claude)."""
     content = [{"type": "text", "text": _bedrock_main_prompt(current_date)}]
     content.append({"cachePoint": {"type": "default"}})
@@ -608,9 +631,13 @@ def _build_bedrock_prompt(current_date, context, tavily_enabled):
     # Always include chart instructions
     content.append({"type": "text", "text": chart_prompt})
 
-    # Conditionally include web search and citation prompts
-    if tavily_enabled:
+    # Conditionally include web search, fetch and citation prompts
+    if web_search_enabled:
         content.append({"type": "text", "text": bedrock_web_search_prompt})
+        if web_fetch_enabled:
+            content.append({"type": "text", "text": bedrock_web_fetch_prompt})
+        else:
+            content.append({"type": "text", "text": snippets_only_prompt})
         content.append({"type": "text", "text": citation_prompt})
 
     content.append({"type": "text", "text": _bedrock_context_prompt(context)})
@@ -619,17 +646,21 @@ def _build_bedrock_prompt(current_date, context, tavily_enabled):
     return SystemMessage(content=content)
 
 
-def _build_openai_prompt(current_date, context, tavily_enabled):
-    """Build system prompt optimized for OpenAI GPT-5.2."""
-    # GPT-5.2: single text block, no cache points needed
+def _build_openai_prompt(current_date, context, web_search_enabled, web_fetch_enabled):
+    """Build system prompt optimized for OpenAI GPT-5.6."""
+    # GPT-5.6: single text block, implicit prompt caching — no cache points needed
     parts = [_openai_main_prompt(current_date)]
 
     # Always include chart instructions (shared verbatim)
     parts.append(chart_prompt)
 
-    # Conditionally include web search and citation prompts
-    if tavily_enabled:
+    # Conditionally include web search, fetch and citation prompts
+    if web_search_enabled:
         parts.append(openai_web_search_prompt)
+        if web_fetch_enabled:
+            parts.append(openai_web_fetch_prompt)
+        else:
+            parts.append(snippets_only_prompt)  # shared verbatim
         parts.append(citation_prompt)  # shared verbatim
 
     parts.append(_openai_context_prompt(context))

--- a/backend/sentry/requirements.txt
+++ b/backend/sentry/requirements.txt
@@ -1,10 +1,21 @@
 
 langgraph>=1.2.4,<1.3.0
-langchain-aws==1.4.3
+langchain-aws==1.6.4
 langchain-openai==1.1.14
+# Mints the SigV4-derived bearer token for GPT models on Bedrock Mantle.
+# Pinned like every other dep here: there is no lock file, so any rebuild
+# re-resolves, and a 2.x that moves or renames provide_token would break
+# _mantle_token_provider's import at container start — taking down all Mantle
+# auth at runtime.
+aws-bedrock-token-generator==1.1.0
 langchain-tavily>=0.2.16
 langgraph-checkpoint-aws==1.0.6
 langchain-mcp-adapters==0.2.2
+# Pin the transitive mcp dep: adapters declares only mcp>=1.9.2, so an
+# unpinned rebuild resolves to mcp 2.x, which relocated
+# mcp.shared.context.RequestContext and crashes the container at import.
+# Every adapters release (through 0.3.2) requires mcp<2.0.0.
+mcp>=1.9.2,<2.0.0
 langchain-task-steering==0.1.8
 uv==0.11.15
 uvicorn[standard]==0.44.0

--- a/backend/sentry/streaming.py
+++ b/backend/sentry/streaming.py
@@ -67,10 +67,12 @@ class StreamingHandler:
         Returns error message if mismatch detected, None otherwise.
         """
         try:
-            # Get current provider
-            from config import MODEL_PROVIDER
+            # Compare message-format families, not raw provider values —
+            # "bedrock-mantle" produces OpenAI-format messages, so it must
+            # match sessions detected as "openai".
+            from config import PROVIDER_MESSAGE_FAMILY
 
-            current_provider = MODEL_PROVIDER
+            current_provider = PROVIDER_MESSAGE_FAMILY
 
             # Get session state
             config = {"configurable": {"thread_id": session_id}}
@@ -141,10 +143,10 @@ class StreamingHandler:
                         elif content_type == "reasoning_content":
                             return "bedrock"
 
-        # Default to current provider if can't detect
-        from config import MODEL_PROVIDER
+        # Default to the current provider's message-format family if can't detect
+        from config import PROVIDER_MESSAGE_FAMILY
 
-        return MODEL_PROVIDER
+        return PROVIDER_MESSAGE_FAMILY
 
     @sse_stream()
     async def handle_streaming_request(

--- a/backend/sentry/utils.py
+++ b/backend/sentry/utils.py
@@ -462,24 +462,27 @@ async def get_or_create_agent(
                 else:
                     logger.warning(f"Failed to retrieve diagram data: {diagram_path}")
 
-            # Check if Tavily tools are in the selected tools
-            tavily_enabled = any(
-                tool.name in ("tavily_search", "tavily_extract") for tool in new_tools
+            # Which web search capability the selected tools actually provide.
+            # Search may come from Tavily or the AgentCore connector; only
+            # Tavily also offers page extraction, so the two are tracked apart
+            # and the prompt drops its fetch guidance when there is no fetch.
+            selected_names = {tool.name for tool in new_tools}
+            web_search_enabled = bool(
+                selected_names & {"tavily_search", "web_search"}
             )
+            web_fetch_enabled = "tavily_extract" in selected_names
 
             # Generate system prompt with enhanced context
-            if context:
-                prompt = system_prompt(context, tavily_enabled=tavily_enabled)
-                logger.debug(
-                    f"Using context-based system prompt (tavily_enabled={tavily_enabled})"
-                )
-            else:
-                prompt = system_prompt(
-                    {}, tavily_enabled=tavily_enabled
-                )  # Default empty context
-                logger.debug(
-                    f"Using default system prompt (empty context, tavily_enabled={tavily_enabled})"
-                )
+            prompt = system_prompt(
+                context if context else {},
+                web_search_enabled=web_search_enabled,
+                web_fetch_enabled=web_fetch_enabled,
+            )
+            logger.debug(
+                f"Using system prompt (context={bool(context)}, "
+                f"web_search_enabled={web_search_enabled}, "
+                f"web_fetch_enabled={web_fetch_enabled})"
+            )
 
             # Create new agent
             new_agent = create_react_agent(

--- a/backend/sentry/web_search_tools.py
+++ b/backend/sentry/web_search_tools.py
@@ -1,0 +1,530 @@
+"""
+AgentCore Web Search Tool Module
+
+Provides a `web_search` tool backed by Bedrock AgentCore's built-in web search
+connector, as an alternative to Tavily. Selected at deploy time via
+WEB_SEARCH_PROVIDER; see infra/web_search.tf.
+
+**Why an MCP client and not an API call.** Web Search on Bedrock AgentCore is
+exposed exclusively as a built-in *connector target* on an AgentCore **Gateway**,
+which speaks MCP over streamable HTTP — there is no direct data-plane search
+call. So this module is a small MCP client:
+
+    initialize -> Mcp-Session-Id -> tools/call {name, arguments}
+
+signed with SigV4 (the gateway's inbound authorizer is AWS_IAM, service
+`bedrock-agentcore`) using the runtime's own execution-role credentials. The
+JSON-RPC is hand-rolled rather than pulling in the async `mcp` SDK: the protocol
+surface needed is two POSTs, and LangChain tools here are synchronous, so an
+async client would need an event-loop bridge inside the running graph loop.
+botocore — already a dependency via boto3 — supplies both the signer and the
+HTTP session, so this adds no new package.
+
+**No fetch/extract counterpart.** The connector offers search only. Unlike
+Tavily (search + extract) there is no way to pull full page content, so when
+this provider is selected the agent gets a single tool and the prompts drop
+their fetch guidance. Snippets are all the agent sees.
+
+**Region.** The connector is offered in us-east-1, eu-west-1, and
+ap-northeast-1 only, so the gateway may live in a different region than the rest
+of the deployment (WEB_SEARCH_REGION). The query never leaves AWS — the gateway
+serves it internally — but it can leave the deployment's region.
+
+**Deliberately no server-side filters.** Connector 1.2.0 added an optional
+`filters` object (domain / published-date). Using it requires pinning the
+gateway target to a connector version, which is not expressible declaratively
+(the CloudFormation registry's ConnectorSource carries only ConnectorId), and a
+pre-1.2.0 target *silently ignores* an unknown `filters` argument rather than
+rejecting it. Rather than advertise arguments that might quietly not apply, this
+implementation stays on the base surface (query + maxResults) and the tool
+description tells the model to put the period in the query text instead.
+"""
+
+import datetime
+import json
+import logging
+import os
+import re
+import threading
+from typing import Any, Callable, List, NamedTuple
+
+logger = logging.getLogger(__name__)
+
+# The connector's own limits (Web Search Tool input schema). Enforced
+# client-side so a too-long query comes back as actionable tool feedback
+# instead of a gateway 400 the model can't interpret.
+QUERY_MAX_CHARS = 200
+RESULTS_MAX = 25
+
+# The MCP protocol revision the gateway examples use.
+_MCP_PROTOCOL_VERSION = "2025-06-18"
+
+# AgentCore Gateway prefixes every tool with its target name, joined by THREE
+# underscores, e.g. `td-sentry-web-search___WebSearch`. Terraform passes the
+# composed name in env; when absent it is discovered from tools/list rather
+# than guessed.
+_WEB_SEARCH_TOOL_SUFFIX = "websearch"
+
+TOOL_NAME = "web_search"
+
+
+class HttpResponse(NamedTuple):
+    """The minimal HTTP response shape this client needs (fakeable in tests)."""
+
+    status: int
+    headers: dict
+    text: str
+
+
+# transport(body, headers) -> HttpResponse
+Transport = Callable[[str, dict], HttpResponse]
+
+
+class WebSearchError(RuntimeError):
+    """A gateway/protocol failure — surfaced to the model as tool feedback."""
+
+
+def _header(headers: Any, name: str):
+    """Case-insensitive header lookup that works on dicts and botocore headers."""
+    if not headers:
+        return None
+    getter = getattr(headers, "get", None)
+    if getter is not None:
+        direct = getter(name)
+        if direct:
+            return direct
+    lowered = name.lower()
+    try:
+        items = headers.items()
+    except AttributeError:
+        return None
+    for key, value in items:
+        if str(key).lower() == lowered:
+            return value
+    return None
+
+
+def _parse_jsonrpc_body(resp: HttpResponse) -> dict:
+    """Decode a JSON-RPC body, whether it came back as JSON or SSE.
+
+    Streamable-HTTP MCP servers may answer a POST with either application/json
+    or a text/event-stream carrying the same JSON in `data:` lines, and the
+    gateway picks based on the request's Accept header. Both are accepted so a
+    server-side change of mind can't break the tool.
+    """
+    body = resp.text or ""
+    ctype = (_header(resp.headers, "Content-Type") or "").lower()
+    if "text/event-stream" in ctype or body.lstrip().startswith("event:"):
+        for line in body.splitlines():
+            if not line.startswith("data:"):
+                continue
+            chunk = line[5:].strip()
+            if not chunk:
+                continue
+            try:
+                parsed = json.loads(chunk)
+            except ValueError:
+                continue
+            # Skip server-initiated notifications; we want the reply to our call.
+            if isinstance(parsed, dict) and ("result" in parsed or "error" in parsed):
+                return parsed
+        raise WebSearchError("gateway returned an event stream with no JSON-RPC result")
+    try:
+        return json.loads(body)
+    except ValueError as e:
+        raise WebSearchError(f"gateway returned a non-JSON body: {body[:200]!r}") from e
+
+
+def _sigv4_transport(url: str, region: str, timeout_s: float) -> Transport:
+    """Build the live transport: SigV4-signed POSTs over botocore's HTTP session.
+
+    Credentials are resolved (and frozen) per request so the container's rotating
+    role credentials keep working across a long-lived runtime session.
+    """
+    import boto3
+    from botocore.auth import SigV4Auth
+    from botocore.awsrequest import AWSRequest
+    from botocore.httpsession import URLLib3Session
+
+    boto_session = boto3.Session()
+    http = URLLib3Session(timeout=timeout_s)
+
+    def send(body: str, headers: dict) -> HttpResponse:
+        creds = boto_session.get_credentials()
+        if creds is None:
+            raise WebSearchError(
+                "no AWS credentials available to sign the gateway call"
+            )
+        request = AWSRequest(method="POST", url=url, data=body, headers=dict(headers))
+        SigV4Auth(
+            creds.get_frozen_credentials(), "bedrock-agentcore", region
+        ).add_auth(request)
+        resp = http.send(request.prepare())
+        text = (
+            resp.text
+            if isinstance(resp.text, str)
+            else (resp.content or b"").decode("utf-8", "replace")
+        )
+        return HttpResponse(status=resp.status_code, headers=resp.headers, text=text)
+
+    return send
+
+
+def normalize_gateway_url(url: str) -> str:
+    """Return the gateway's MCP endpoint (Terraform's URL may omit /mcp)."""
+    trimmed = (url or "").strip().rstrip("/")
+    if not trimmed:
+        return ""
+    return trimmed if trimmed.endswith("/mcp") else f"{trimmed}/mcp"
+
+
+_MONTHS = {
+    name: number
+    for number, name in enumerate(
+        "january february march april may june july august "
+        "september october november december".split(),
+        start=1,
+    )
+}
+
+
+def parse_published_date(value: Any):
+    """Best-effort publishedDate -> date (the connector's format is unpinned).
+
+    Results carry ISO dates and full timestamps, but also prose
+    ("05:00PM, Sunday, October 06 2024, PDT"); anything unreadable counts as
+    UNDATED rather than silently mapping to today.
+    """
+    if not isinstance(value, str):
+        return None
+    iso = re.match(r"\s*(\d{4})-(\d{2})-(\d{2})", value)
+    if iso:
+        parts = (int(iso[1]), int(iso[2]), int(iso[3]))
+    else:
+        prose = re.search(r"([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})", value)
+        if not prose or prose[1].lower() not in _MONTHS:
+            return None
+        parts = (int(prose[3]), _MONTHS[prose[1].lower()], int(prose[2]))
+    try:
+        return datetime.date(*parts)
+    except ValueError:
+        return None
+
+
+class WebSearchGateway:
+    """MCP client for the gateway's `WebSearch` connector tool.
+
+    The MCP session id is cached on the instance (one initialize per process
+    rather than per search) and re-established transparently when the gateway
+    expires it. `transport` is injectable so tests exercise the protocol
+    without AWS.
+    """
+
+    def __init__(
+        self,
+        gateway_url: str,
+        region: str = "us-east-1",
+        tool_name: str = "",
+        default_max_results: int = 5,
+        timeout_s: float = 20.0,
+        transport=None,
+        today=None,
+    ) -> None:
+        self.url = normalize_gateway_url(gateway_url)
+        if not self.url:
+            raise ValueError("gateway_url is required")
+        self.region = region
+        self.default_max_results = max(1, min(RESULTS_MAX, default_max_results))
+        self._tool_name = (tool_name or "").strip()
+        self._transport = transport or _sigv4_transport(self.url, region, timeout_s)
+        self._today = today or (
+            lambda: datetime.datetime.now(datetime.timezone.utc).date()
+        )
+        self._session_id = None
+        self._next_id = 0
+        # One MCP session is shared by every caller, and LangGraph runs sync
+        # tools on a thread pool, so concurrent searches would otherwise race:
+        # one thread clearing _session_id to re-handshake while another POSTs
+        # with the id it just replaced, and both handing out the same _next_id.
+        # Re-entrant because search() -> _resolve_tool_name() -> _rpc().
+        self._lock = threading.RLock()
+
+    # --- MCP plumbing --------------------------------------------------------
+
+    def _post(self, payload: dict, session_id) -> HttpResponse:
+        headers = {
+            "Content-Type": "application/json",
+            # The MCP streamable-HTTP transport requires the client to accept
+            # both; the gateway may answer either way.
+            "Accept": "application/json, text/event-stream",
+        }
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+        return self._transport(json.dumps(payload), headers)
+
+    def _rpc(self, method: str, params: dict, retry_session: bool = True) -> dict:
+        """One JSON-RPC call, (re-)initializing the session as needed.
+
+        Serialized on the instance lock: the session id and request counter are
+        shared, so overlapping calls have to take turns.
+        """
+        with self._lock:
+            return self._rpc_locked(method, params, retry_session)
+
+    def _rpc_locked(self, method: str, params: dict, retry_session: bool) -> dict:
+        if self._session_id is None:
+            self._initialize()
+        self._next_id += 1
+        resp = self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": f"sentry-{self._next_id}",
+                "method": method,
+                "params": params,
+            },
+            self._session_id,
+        )
+        # A dropped/expired session shows up as a 4xx on an otherwise valid
+        # call; re-handshake once before treating it as a real failure.
+        if resp.status in (400, 404) and retry_session:
+            logger.info(
+                f"web_search session rejected ({resp.status}) - re-initializing"
+            )
+            self._session_id = None
+            return self._rpc_locked(method, params, retry_session=False)
+        if resp.status >= 300:
+            raise WebSearchError(
+                f"gateway {method} failed with HTTP {resp.status}: "
+                f"{(resp.text or '')[:300]}"
+            )
+        body = _parse_jsonrpc_body(resp)
+        if isinstance(body.get("error"), dict):
+            err = body["error"]
+            raise WebSearchError(
+                f"gateway {method} error {err.get('code')}: {err.get('message')}"
+            )
+        result = body.get("result")
+        if not isinstance(result, dict):
+            raise WebSearchError(f"gateway {method} returned no result object")
+        return result
+
+    def _initialize(self) -> None:
+        resp = self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": "sentry-init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": _MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "threat-designer-sentry", "version": "1.0.0"},
+                },
+            },
+            None,
+        )
+        if resp.status >= 300:
+            raise WebSearchError(
+                f"gateway initialize failed with HTTP {resp.status}: "
+                f"{(resp.text or '')[:300]}"
+            )
+        _parse_jsonrpc_body(resp)  # surfaces a JSON-RPC error as WebSearchError
+        # A stateless gateway may not vend a session id at all; carry on
+        # without one rather than failing (it is only echoed back when present).
+        self._session_id = _header(resp.headers, "Mcp-Session-Id") or ""
+
+    def _resolve_tool_name(self) -> str:
+        """The gateway-side tool name, from config or discovered via tools/list."""
+        with self._lock:
+            return self._resolve_tool_name_locked()
+
+    def _resolve_tool_name_locked(self) -> str:
+        if self._tool_name:
+            return self._tool_name
+        result = self._rpc("tools/list", {})
+        names = [
+            t.get("name")
+            for t in (result.get("tools") or [])
+            if isinstance(t, dict) and t.get("name")
+        ]
+        for name in names:
+            # `<target>___WebSearch` — match on the suffix so the target name
+            # is free to change without a code change.
+            if str(name).lower().replace("_", "").endswith(_WEB_SEARCH_TOOL_SUFFIX):
+                self._tool_name = str(name)
+                return self._tool_name
+        raise WebSearchError(
+            "no WebSearch tool on the gateway (tools/list returned: "
+            f"{', '.join(str(n) for n in names) or 'nothing'})"
+        )
+
+    # --- the search itself ---------------------------------------------------
+
+    def search(self, query: str, max_results=None) -> dict:
+        """Run one web search; return normalized results.
+
+        Raises ValueError for bad arguments (the tool turns those into
+        actionable feedback) and WebSearchError for gateway failures.
+        """
+        cleaned = (query or "").strip()
+        if not cleaned:
+            raise ValueError("query must not be empty")
+        if len(cleaned) > QUERY_MAX_CHARS:
+            raise ValueError(
+                f"query must be {QUERY_MAX_CHARS} characters or fewer "
+                f"(got {len(cleaned)}) — search for the key terms, not a sentence"
+            )
+        wanted = max_results or self.default_max_results
+        if wanted < 1:
+            raise ValueError("max_results must be at least 1")
+        wanted = min(RESULTS_MAX, wanted)
+
+        # Held across both calls so the resolved tool name and the call that uses
+        # it see the same session.
+        with self._lock:
+            result = self._rpc(
+                "tools/call",
+                {
+                    "name": self._resolve_tool_name(),
+                    "arguments": {"query": cleaned, "maxResults": wanted},
+                },
+            )
+        if result.get("isError"):
+            raise WebSearchError(f"web search failed: {_result_text(result)[:300]}")
+
+        results = []
+        for item in _extract_results(result):
+            published = parse_published_date(item.get("publishedDate"))
+            results.append(
+                {
+                    "title": item.get("title") or "",
+                    "url": item.get("url") or "",
+                    # Normalized to ISO (or None) so the UI and the model read
+                    # one shape whatever format the connector used.
+                    "published_date": published.isoformat() if published else None,
+                    "text": item.get("text") or "",
+                }
+            )
+        return {
+            "query": cleaned,
+            "as_of": self._today().isoformat(),
+            "result_count": len(results),
+            "results": results,
+        }
+
+
+def _result_text(result: dict) -> str:
+    """Concatenate the text parts of an MCP tool result's content blocks."""
+    parts = []
+    for block in result.get("content") or []:
+        if isinstance(block, dict) and isinstance(block.get("text"), str):
+            parts.append(block["text"])
+    return "\n".join(parts)
+
+
+def _extract_results(result: dict) -> List[dict]:
+    """Pull the result list out of an MCP tool result.
+
+    The connector answers with the search payload JSON-encoded inside a text
+    content block and, per the MCP spec, may ALSO provide it pre-parsed as
+    `structuredContent`. Prefer the structured form when present.
+    """
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict) and isinstance(structured.get("results"), list):
+        return [r for r in structured["results"] if isinstance(r, dict)]
+    text = _result_text(result).strip()
+    if not text:
+        return []
+    try:
+        decoded = json.loads(text)
+    except ValueError as e:
+        raise WebSearchError(
+            f"could not decode search results: {text[:200]!r}"
+        ) from e
+    if isinstance(decoded, dict) and isinstance(decoded.get("results"), list):
+        return [r for r in decoded["results"] if isinstance(r, dict)]
+    if isinstance(decoded, list):
+        return [r for r in decoded if isinstance(r, dict)]
+    return []
+
+
+# The description the model sees. It deliberately carries NO date: a tool's
+# description is built once per container and an AgentCore container serves
+# sessions for hours or days, so a stamp baked in here goes stale and tells the
+# model the wrong "now". prompt.system_prompt() interpolates current_date on
+# every request, which is the date the model should reason from; the reminder
+# below to put the period in the query text is what makes that date usable here.
+_DESCRIPTION = (
+    "Search the public web and return ranked results (title, url, publication "
+    "date, and a relevant text snippet).\n"
+    "Use this for security context that lives outside the threat model: current "
+    "CVEs and advisories, active exploit campaigns, new attack techniques, or a "
+    "fact published after your training cutoff. Do not use it for what a threat, "
+    "asset, or data flow in this threat model MEANS — that is in the model "
+    "itself.\n"
+    "Args: `query` is a short keyword phrase, {max_chars} characters or fewer "
+    "(not a sentence). `max_results` is 1-{results_max} (default {default}).\n"
+    "Results are ranked by RELEVANCE, not date, and there is no date filter — "
+    "when the question concerns a specific period, put the period in the query "
+    'itself ("Log4Shell exploitation 2026") and check each result\'s publication '
+    "date before treating it as evidence for that period.\n"
+    "This tool returns SNIPPETS only — there is no way to fetch full page "
+    "content, so do not promise the user a deeper read of a page. Treat snippets "
+    "as claims by their source, not as facts: say who reported what."
+)
+
+
+def make_web_search_tool(engine: WebSearchGateway):
+    """Wrap a WebSearchGateway as the LangChain `web_search` tool."""
+    from langchain_core.tools import StructuredTool
+
+    description = _DESCRIPTION.format(
+        max_chars=QUERY_MAX_CHARS,
+        results_max=RESULTS_MAX,
+        default=engine.default_max_results,
+    )
+
+    def web_search(query: str, max_results: int = 0):
+        # A failure comes back as the tool's RESULT so the model can react
+        # (rephrase, or tell the user the lookup failed) instead of aborting.
+        try:
+            return engine.search(query, max_results=max_results or None)
+        except ValueError as e:  # bad arguments — concise + actionable
+            return f"Error: {e}"
+        except Exception as e:  # noqa: BLE001 - a tool error is feedback
+            logger.warning("web_search failed", exc_info=True)
+            return f"Error: web_search failed: {type(e).__name__}: {e}"
+
+    return StructuredTool.from_function(
+        func=web_search, name=TOOL_NAME, description=description
+    )
+
+
+def get_agentcore_web_search_tools() -> List:
+    """Return `[web_search]` when the AgentCore gateway is configured, else `[]`.
+
+    Both a gateway URL and a region are required: without the URL the runtime
+    has nothing to call, and the execution role carries no InvokeGateway grant
+    unless the deployment provisioned the gateway, so offering the tool would
+    only produce 403s the model can't act on.
+    """
+    url = os.environ.get("WEB_SEARCH_GATEWAY_URL", "")
+    if not url.strip():
+        logger.warning(
+            "WEB_SEARCH_PROVIDER is agentcore but WEB_SEARCH_GATEWAY_URL is "
+            "empty - web_search will not be available"
+        )
+        return []
+    try:
+        engine = WebSearchGateway(
+            gateway_url=url,
+            region=os.environ.get("WEB_SEARCH_REGION", "us-east-1"),
+            tool_name=os.environ.get("WEB_SEARCH_TOOL_NAME", ""),
+            default_max_results=int(os.environ.get("WEB_SEARCH_MAX_RESULTS", "5")),
+        )
+        return [make_web_search_tool(engine)]
+    except Exception:  # noqa: BLE001 - a misconfigured gateway must not break Sentry
+        logger.warning(
+            "could not build the AgentCore web search client - web_search off",
+            exc_info=True,
+        )
+        return []

--- a/backend/threat_designer/agent.py
+++ b/backend/threat_designer/agent.py
@@ -24,11 +24,10 @@ from constants import (
     HTTP_STATUS_BAD_REQUEST,
     HTTP_STATUS_INTERNAL_SERVER_ERROR,
     HTTP_STATUS_UNPROCESSABLE_ENTITY,
-    REASONING_DISABLED,
-    VALID_REASONING_VALUES,
     DEFAULT_MAX_RETRY,
     JobState,
     Methodology,
+    normalize_reasoning_level,
 )
 from exceptions import ThreatModelingError, ValidationError
 from model_utils import initialize_models
@@ -145,13 +144,15 @@ def _run_agent_async(state: Dict, config: Dict, job_id: str, agent_config: Dict)
 
                 # Attack tree always uses reasoning with fixed budget
                 # For Bedrock (Claude): 48000 tokens
-                # For OpenAI (GPT-5.2): "medium" effort
+                # For OpenAI (GPT-5.6): "medium" effort
                 # This is hardcoded and not user-configurable
                 ATTACK_TREE_REASONING_LEVEL = (
                     2  # Maps to 48000 for Bedrock, "medium" for OpenAI
                 )
 
-                models = initialize_models(ATTACK_TREE_REASONING_LEVEL)
+                models = initialize_models(
+                    ATTACK_TREE_REASONING_LEVEL, owner=state.get("owner")
+                )
                 attack_tree_model = models.get("attack_tree_agent_model")
 
                 if not attack_tree_model:
@@ -245,13 +246,15 @@ def _create_agent_config(event: Dict[str, Any]) -> ConfigSchema:
     Returns:
         ConfigSchema: Properly typed configuration for the agent
     """
-    reasoning = int(event.get("reasoning") or REASONING_DISABLED)
-    models = initialize_models(reasoning)
-    thinking = reasoning != REASONING_DISABLED
+    reasoning = normalize_reasoning_level(event.get("reasoning"))
+    models = initialize_models(reasoning, owner=event.get("owner"))
+    # Every level runs the model with thinking on, so the auto tool choice and
+    # the structured-output retry path are always in effect.
+    thinking = True
 
     logger.debug(
         "Created agent configuration",
-        reasoning=thinking,
+        reasoning_level=reasoning,
     )
 
     return {
@@ -610,18 +613,19 @@ def _validate_event(event: Dict[str, Any]) -> None:
         )
         raise ValidationError(f"{ERROR_MISSING_REQUIRED_FIELDS}: {missing_fields}")
 
-    # Validate reasoning parameter if provided
+    # Validate reasoning parameter if provided. normalize_reasoning_level
+    # rejects out-of-range values and clamps the legacy 0 up to the minimum.
     if "reasoning" in event:
         try:
-            reasoning_value = int(event["reasoning"])
-            if reasoning_value not in VALID_REASONING_VALUES:
-                logger.error(
-                    "Invalid reasoning value",
-                    reasoning_value=reasoning_value,
-                    expected_values=VALID_REASONING_VALUES,
-                )
-                raise ValidationError(ERROR_INVALID_REASONING_VALUE)
-        except (ValueError, TypeError) as e:
+            normalize_reasoning_level(event["reasoning"])
+        except ValueError as e:
+            logger.error(
+                "Invalid reasoning value",
+                reasoning_value=event["reasoning"],
+                error=str(e),
+            )
+            raise ValidationError(ERROR_INVALID_REASONING_VALUE)
+        except TypeError as e:
             logger.error(
                 "Invalid reasoning parameter type",
                 reasoning_param=event["reasoning"],

--- a/backend/threat_designer/attack_tree_models.py
+++ b/backend/threat_designer/attack_tree_models.py
@@ -36,7 +36,11 @@ class AttackTechnique(BaseModel):
     name: str = Field(..., description="Name of the attack technique")
 
     description: str = Field(
-        ..., description="Detailed description of how the attack works"
+        ...,
+        description=(
+            "How the step works at design level: the weakness it relies on and "
+            "what it gains the attacker. No commands, code, or payloads."
+        ),
     )
 
     attack_phase: Literal[
@@ -73,7 +77,11 @@ class AttackTechnique(BaseModel):
     )
 
     techniques: List[str] = Field(
-        ..., description="Specific techniques and methods used"
+        ...,
+        description=(
+            "Named technique classes, using MITRE ATT&CK technique names or IDs "
+            "where one applies. Categories of method, not tooling or procedures."
+        ),
     )
 
 
@@ -213,7 +221,11 @@ class LeafAttackNodeData(NodeData):
     )
 
     description: Optional[str] = Field(
-        None, description="Detailed description of the attack technique"
+        None,
+        description=(
+            "The attack technique at design level: the weakness it relies on and "
+            "what it gains the attacker. No commands, code, or payloads."
+        ),
     )
 
     prerequisites: Optional[List[str]] = Field(
@@ -221,7 +233,11 @@ class LeafAttackNodeData(NodeData):
     )
 
     techniques: Optional[List[str]] = Field(
-        None, description="List of specific techniques and methods used in the attack"
+        None,
+        description=(
+            "Named technique classes, using MITRE ATT&CK technique names or IDs "
+            "where one applies. Categories of method, not tooling or procedures."
+        ),
     )
 
     skillLevel: Optional[Literal["novice", "intermediate", "expert"]] = Field(

--- a/backend/threat_designer/attack_tree_prompts.py
+++ b/backend/threat_designer/attack_tree_prompts.py
@@ -4,6 +4,12 @@ Attack Tree Prompt Generation Module
 This module provides prompt generation functions for attack tree generation workflow.
 The prompts guide the LLM agent to generate comprehensive attack trees using MITRE ATT&CK
 framework and ReACT pattern.
+
+A single prompt serves every provider (Claude 5 family and GPT-5.6 alike); only
+cache-point placement differs. It is written for both: no narrated self-review
+or re-check steps (the Claude 5 models self-verify, and such instructions cause
+over-verification), each instruction stated once (GPT-5.6 rewards leaner
+prompts), and narration cadence steered explicitly.
 """
 
 import os
@@ -30,13 +36,23 @@ def create_attack_tree_system_prompt(
 You are an expert security analyst specializing in attack tree generation and threat analysis. You create comprehensive, realistic attack trees that map potential attack paths for identified security threats, aligned with the MITRE ATT&CK framework.
 </role>
 
+<purpose>
+This is defensive threat modeling of a system the operator owns and is responsible for securing. The tree is a design-review artifact: it drives control selection, detection coverage, and mitigation planning for that system.
+
+Stay at design level throughout. A reviewer needs to know which paths exist, what each step depends on, and where a control breaks the chain — not how to carry a step out. Name and classify techniques; do not supply the means to execute them. No commands, no scripts or exploit code, no payloads or proof-of-concept input, no tool configuration, no step-by-step procedures. A tree that reads as input to a mitigation plan is correct; one that reads as an operator's runbook is not, and the operational detail is not what makes a tree useful anyway.
+</purpose>
+
 <tool_usage>
-You have access to five tools: add_attack_node, update_attack_node, delete_attack_node, create_attack_tree, and validate_attack_tree.
+You have access to six tools: create_attack_tree, read_attack_tree, add_attack_node, update_attack_node, delete_attack_node, and validate_attack_tree.
 
 CRITICAL: Call exactly one tool per turn. Calling multiple tools in a single turn will cause tree generation to fail.
 
 <tool name="add_attack_node">
-Adds a logic gate (AND/OR) or leaf node to the tree. Always specify parent_id (None for root-level children). Verify scope and validation rules are satisfied before adding.
+Adds a logic gate (AND/OR) or leaf node to the tree. Always specify parent_id (None for root-level children). Check scope and validation rules are satisfied before adding.
+</tool>
+
+<tool name="read_attack_tree">
+Returns the current tree structure. Use it to re-ground on the built tree before a change batch, or after validate_attack_tree reports issues.
 </tool>
 
 <tool name="update_attack_node">
@@ -57,20 +73,14 @@ Performs gap analysis and rule validation on the current tree. Always call this 
 </tool_usage>
 
 <workflow>
-Follow this incremental build-and-validate cycle:
+Build the tree top-down: start with the root goal and its high-level branch structure, then flesh out each branch incrementally with one tool call per turn. Track which branches exist and how they relate so you don't create redundant or orphaned nodes.
 
-1. REASON: Before each tool call, articulate your current understanding of the tree state, what structural gap you're filling, and which rules apply. Think about the overall attack narrative.
-
-2. ACT: Make a single tool call to build or modify the tree.
-
-3. REFLECT: After receiving tool output, evaluate whether the result maintains structural integrity, logical consistency, and scope containment. Update your mental model of the current tree state.
-
-4. ITERATE: Repeat steps 1-3 until the tree is complete. Track which branches exist and their relationships so you don't create redundant or orphaned nodes.
-
-5. VALIDATE: Call validate_attack_tree as your final action. Resolve any issues it surfaces before finishing.
-
-Start with the root node and high-level structure, then flesh out branches incrementally. Build the tree top-down, validating your mental model at each step.
+Call validate_attack_tree as your final action and resolve any issues it surfaces before finishing.
 </workflow>
+
+<progress_updates>
+Before your first tool call, state in one sentence how you plan to decompose this threat. While building, add a brief update only when you start a new top-level branch or when a validation result changes your plan. Do not narrate routine tool calls or restate the tree after every node.
+</progress_updates>
 
 <attack_tree_structure>
 An attack tree is a hierarchical representation of how an attacker might achieve a goal. It has three node types: one Root, Logic Gates, and Leaf Nodes.
@@ -97,15 +107,15 @@ Likelihood propagation: AND gate likelihood cannot exceed the minimum of its chi
 Leaf nodes represent specific attack techniques. Each must include:
 
 - Name: Include a specific action verb (Exploit, Intercept, Craft, Bypass, Replay, Enumerate, etc.)
-- Description: Multi-technique detail explaining how the attack works
+- Description: The weakness the step relies on and what it gains the attacker, at the detail a reviewer needs to choose a control
 - Attack Phase: The MITRE ATT&CK phase where this technique is normally used
 - Impact Severity: low, medium, high, or critical
 - Likelihood: low, medium, high, or critical
 - Skill Level: novice, intermediate, or expert
 - Prerequisites: Conditions required, which must be achievable within the tree's scope without hidden external capabilities
-- Techniques: Specific tools, methods, or steps used
+- Techniques: Named technique classes, using MITRE ATT&CK technique names or IDs where one applies — the category of method, not tooling or procedure
 
-Descriptions must provide actionable intelligence — defenders should be able to derive detection or prevention measures from them. Avoid vague labels like "Weakness" or "Vulnerability" without specifics.
+Descriptions must be specific enough to act on: a reviewer should be able to derive a detection or a preventive control from each one. Avoid vague labels like "Weakness" or "Vulnerability" without specifics, and equally avoid detail that would not change which control you would choose.
 </leaf_nodes>
 
 <example>
@@ -153,7 +163,7 @@ Realism: use practical, well-documented attack techniques that reflect real atta
 
 Structural correctness: AND gates for complementary conditions, OR gates for alternatives to the same objective. Phase ordering respected parent-to-child. Severity and likelihood propagate correctly through gates.
 
-Actionability: every technique should be detectable or preventable by defenders. Prerequisites should be monitorable or enforceable. Only include attack vectors the customer can control.
+Actionability: every technique should be detectable or preventable, and each one should point at the control that addresses it. Prerequisites should be monitorable or enforceable. Only include attack vectors the customer can control.
 </quality_criteria>
 """
 
@@ -167,8 +177,8 @@ Actionability: every technique should be detectable or preventable by defenders.
     else:
         final_prompt = main_prompt
 
-    # Build content with conditional cache points (Bedrock only)
-    # For OpenAI, caching is handled automatically
+    # Build content with conditional cache points (Bedrock Converse only).
+    # Both GPT transports — direct OpenAI and Bedrock Mantle — cache implicitly.
     if MODEL_PROVIDER == "bedrock":
         content = [
             {"type": "text", "text": final_prompt},
@@ -267,17 +277,17 @@ Create an attack tree that:
 1. Uses the threat name as the root goal
 2. Identifies multiple realistic attack paths an attacker could take
 3. Uses AND/OR logic gates to represent attack path relationships
-4. Provides detailed attack techniques as leaf nodes
+4. Provides attack techniques as leaf nodes, described at design level
 5. Classifies techniques using MITRE ATT&CK phases
 6. Includes realistic severity, likelihood, and skill level assessments
-7. Specifies prerequisites and specific techniques for each attack
+7. Specifies prerequisites and named technique classes for each step
 
-Start by reasoning about the threat and planning your approach, then use the available tools to build the attack tree incrementally.
+Use the available tools to build the attack tree incrementally.
 </task>
 """
 
-    # Build content with conditional cache points (Bedrock only)
-    # For OpenAI, caching is handled automatically
+    # Build content with conditional cache points (Bedrock Converse only).
+    # Both GPT transports — direct OpenAI and Bedrock Mantle — cache implicitly.
     if MODEL_PROVIDER == "bedrock":
         # If architecture image is provided, create multimodal message with cache point
         if architecture_image:
@@ -299,15 +309,16 @@ Start by reasoning about the threat and planning your approach, then use the ava
                 {"cachePoint": {"type": "default"}},
             ]
     else:
-        # OpenAI: caching is automatic, use simple format
+        # GPT (direct OpenAI or Bedrock Mantle): caching is automatic, and images
+        # ride as an image_url data URI — the Bedrock-native {"type": "image",
+        # "source": {...}} block above is not valid on the Responses API. This
+        # matches message_builder.base_msg.
         if architecture_image:
             message_content = [
                 {
-                    "type": "image",
-                    "source": {
-                        "type": "base64",
-                        "media_type": "image/png",
-                        "data": architecture_image,
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{architecture_image}"
                     },
                 },
                 {"type": "text", "text": message_text},

--- a/backend/threat_designer/constants.py
+++ b/backend/threat_designer/constants.py
@@ -5,6 +5,7 @@ This module contains all constants used throughout the threat modeling system,
 organized by logical categories for better maintainability and consistency.
 """
 
+import hashlib
 from enum import Enum
 from typing import Dict, List
 
@@ -36,7 +37,21 @@ ENV_ADAPTIVE_THINKING_MODELS = "ADAPTIVE_THINKING_MODELS"
 ENV_MODEL_PROVIDER = "MODEL_PROVIDER"
 MODEL_PROVIDER_BEDROCK = "bedrock"
 MODEL_PROVIDER_OPENAI = "openai"
+# GPT models served through the Bedrock Mantle OpenAI-compatible endpoint —
+# same models and prompts as the "openai" provider, but SigV4 bearer-token
+# auth instead of an OpenAI API key.
+MODEL_PROVIDER_BEDROCK_MANTLE = "bedrock-mantle"
+# Providers that serve OpenAI GPT models (shared prompts, message format, and
+# reasoning-effort semantics); they differ only in transport/auth.
+OPENAI_FAMILY_PROVIDERS = (MODEL_PROVIDER_OPENAI, MODEL_PROVIDER_BEDROCK_MANTLE)
 ENV_OPENAI_API_KEY = "OPENAI_API_KEY"
+
+# Bedrock Mantle configuration. GPT-5.x on Mantle is served only from US
+# regions (us-east-2 / us-west-2), independent of the deployment region.
+ENV_MANTLE_REGION = "MANTLE_REGION"
+DEFAULT_MANTLE_REGION = "us-east-2"
+# Mantle GPT model IDs carry an "openai." prefix (e.g. "openai.gpt-5.6-sol").
+MANTLE_MODEL_PREFIX = "openai."
 
 
 # ============================================================================
@@ -68,9 +83,9 @@ DEFAULT_MAX_SUMMARY_WORDS = 100
 # Stop sequences for model generation
 STOP_SEQUENCES: List[str] = ["Human:", "User:", "Assistant:"]
 
-# Model temperature settings
-MODEL_TEMPERATURE_DEFAULT = 0
-MODEL_TEMPERATURE_REASONING = 1
+# No temperature settings: Claude 4.6+ and the whole GPT-5 family reject the
+# parameter, and pre-4.6 models with thinking enabled require the default of 1.
+# See _build_adaptive_model_config / _create_openai_model in model_utils.py.
 
 
 # ============================================================================
@@ -324,7 +339,7 @@ ERROR_DYNAMODB_OPERATION_FAILED = "DynamoDB operation failed"
 ERROR_S3_OPERATION_FAILED = "S3 operation failed"
 ERROR_VALIDATION_FAILED = "Request validation failed"
 ERROR_MISSING_REQUIRED_FIELDS = "Missing required fields"
-ERROR_INVALID_REASONING_VALUE = "Reasoning must be 0 or 1"
+ERROR_INVALID_REASONING_VALUE = "Reasoning must be an integer between 1 and 4"
 ERROR_INVALID_REASONING_TYPE = "Invalid reasoning parameter"
 
 
@@ -341,10 +356,17 @@ HTTP_STATUS_INTERNAL_SERVER_ERROR = 500
 # REASONING CONFIGURATION
 # ============================================================================
 
-# Valid reasoning levels
-REASONING_DISABLED = 0
-REASONING_ENABLED = [1, 2, 3, 4]
-VALID_REASONING_VALUES = [REASONING_DISABLED, *REASONING_ENABLED]
+# Reasoning levels: 1-4, with no "off" level.
+#
+# Every current model is a reasoning model. On Claude Opus 5 thinking is on by
+# default and cannot be disabled above effort "high", and omitting the thinking
+# config does not turn it off — it runs adaptive thinking at the provider's
+# default effort. An "off" level therefore promised something the models no
+# longer deliver: it billed for thinking while discarding the reasoning output.
+# Level 1 (low effort) is the cheap end of the ladder instead. The range itself
+# lives in MIN_REASONING_LEVEL/MAX_REASONING_LEVEL below, which
+# normalize_reasoning_level enforces.
+DEFAULT_REASONING_LEVEL = 1
 
 # Reasoning model configuration
 REASONING_THINKING_TYPE = "enabled"
@@ -352,33 +374,35 @@ REASONING_BUDGET_FIELD = "budget_tokens"
 
 # Adaptive thinking configuration
 ADAPTIVE_THINKING_TYPE = "adaptive"
-ADAPTIVE_EFFORT_MAP: Dict[int, str] = {1: "low", 2: "medium", 3: "high", 4: "max"}
+# Level 4 tops out at "xhigh", not "max": xhigh is the recommended setting for
+# demanding coding and agentic work, while max costs substantially more for
+# marginal gains. Models still accept "max" if a per-model effort_map sets it.
+ADAPTIVE_EFFORT_MAP: Dict[int, str] = {1: "low", 2: "medium", 3: "high", 4: "xhigh"}
 
-# OpenAI reasoning effort mapping for mini models
-OPENAI_REASONING_EFFORT_MAP_MINI: Dict[int, str] = {
-    0: "minimal",
+# OpenAI reasoning effort mapping. GPT-5.6 (Sol/Terra/Luna) accepts
+# none|low|medium|high|xhigh|max across the whole fleet — "minimal" was
+# removed and is rejected with a 400 — so a single map serves every model.
+# Level 4 tops out at "xhigh" for the same cost/quality reason as the adaptive
+# map above; "max" stays available via a per-model reasoning_effort override.
+OPENAI_REASONING_EFFORT_MAP: Dict[int, str] = {
+    0: "none",
     1: "low",
     2: "medium",
     3: "high",
     4: "xhigh",
 }
 
-# OpenAI reasoning effort mapping for standard models
-OPENAI_REASONING_EFFORT_MAP_STANDARD: Dict[int, str] = {
-    0: "minimal",
-    1: "minimal",
-    2: "low",
-    3: "low",
-    4: "xhigh",
-}
-
 # Known GPT-5 family models that support reasoning
 OPENAI_GPT5_FAMILY_MODELS: List[str] = [
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.4-2026-03-05",
     "gpt-5.2-2025-12-11",
     "gpt-5.1-2025-11-13",
     "gpt-5-2025-08-07",
     "gpt-5-mini-2025-08-07",
-    "gpt-5.4-2026-03-05",
 ]
 
 
@@ -416,8 +440,58 @@ MIN_SUMMARY_WORDS = 10
 MAX_SUMMARY_WORDS = 100
 
 # Reasoning level validation
-MIN_REASONING_LEVEL = 0
+MIN_REASONING_LEVEL = 1
 MAX_REASONING_LEVEL = 4
+
+# Legacy clients (a cached frontend bundle, an older CLI, the MCP server) may
+# still send 0, which used to mean "no thinking". It is accepted at the API
+# boundary and normalized to the minimum level rather than rejected, so
+# replaying an existing threat model keeps working.
+LEGACY_REASONING_DISABLED = 0
+
+
+# ============================================================================
+# SAFETY IDENTIFIER
+# ============================================================================
+
+# Namespace prefix so the same user hashes differently here than in any other
+# system that might hash the same Cognito sub.
+_SAFETY_ID_NAMESPACE = "threat-designer:"
+
+
+def safety_identifier(owner) -> str:
+    """A stable, privacy-preserving per-user id for OpenAI's safety_identifier.
+
+    OpenAI uses this to attribute traffic per end user, which reduces
+    false-positive trips of the real-time cyber/bio misuse classifiers on
+    legitimate dual-use work such as threat modeling. It must be STABLE for a
+    given user (so a hash, not a per-request value) and must not carry PII —
+    hence a namespaced SHA-256 of the Cognito sub rather than the sub itself.
+
+    Returns "" when there is no owner, so the caller can omit the field.
+    """
+    if not owner:
+        return ""
+    return hashlib.sha256(f"{_SAFETY_ID_NAMESPACE}{owner}".encode("utf-8")).hexdigest()
+
+
+def normalize_reasoning_level(value) -> int:
+    """Coerce an incoming reasoning level onto the supported 1-4 ladder.
+
+    ``None`` (absent) resolves to :data:`DEFAULT_REASONING_LEVEL`, and the
+    legacy 0 clamps up to :data:`MIN_REASONING_LEVEL`.
+
+    Raises:
+        ValueError: for non-numeric input or a level outside 0-4.
+    """
+    if value is None or value == "":
+        return DEFAULT_REASONING_LEVEL
+    level = int(value)
+    if level < LEGACY_REASONING_DISABLED or level > MAX_REASONING_LEVEL:
+        raise ValueError(
+            f"reasoning must be between {MIN_REASONING_LEVEL} and {MAX_REASONING_LEVEL}"
+        )
+    return max(level, MIN_REASONING_LEVEL)
 
 
 # ============================================================================

--- a/backend/threat_designer/model_utils.py
+++ b/backend/threat_designer/model_utils.py
@@ -9,6 +9,8 @@ AWS Bedrock and OpenAI providers.
 import functools
 import json
 import os
+import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, TypedDict
 
@@ -18,23 +20,26 @@ from constants import (
     ADAPTIVE_EFFORT_MAP,
     ADAPTIVE_THINKING_TYPE,
     AWS_SERVICE_BEDROCK_RUNTIME,
+    DEFAULT_MANTLE_REGION,
     DEFAULT_REGION,
     DEFAULT_TIMEOUT,
     ENV_ADAPTIVE_THINKING_MODELS,
     ENV_MAIN_MODEL,
+    ENV_MANTLE_REGION,
     ENV_MODEL_PROVIDER,
     ENV_MODEL_STRUCT,
     ENV_MODEL_SUMMARY,
     ENV_OPENAI_API_KEY,
     ENV_REGION,
+    MANTLE_MODEL_PREFIX,
     MODEL_PROVIDER_BEDROCK,
+    MODEL_PROVIDER_BEDROCK_MANTLE,
     MODEL_PROVIDER_OPENAI,
-    MODEL_TEMPERATURE_DEFAULT,
-    MODEL_TEMPERATURE_REASONING,
     OPENAI_GPT5_FAMILY_MODELS,
     REASONING_BUDGET_FIELD,
     REASONING_THINKING_TYPE,
     STOP_SEQUENCES,
+    safety_identifier,
 )
 from exceptions import ModelProviderError, OpenAIAuthenticationError
 from langchain_aws.chat_models.bedrock import ChatBedrockConverse
@@ -232,17 +237,20 @@ def _build_standard_model_config(
     model_config: ModelConfig,
     client: boto3.client,
     region: str,
-    adaptive_models: list[str] | None = None,
 ) -> dict:
     """
     Build standard model configuration dictionary.
+
+    No temperature is sent. Claude 4.6+ (including Opus 5 / Sonnet 5) removed
+    the sampling parameters and reject them outright, and pre-4.6 models default
+    to 1.0 — which is also the only value they accept while thinking is enabled.
+    Omitting it keeps one code path for every model and removes the dependence
+    on the adaptive-model list being accurate.
 
     Args:
         model_config: Model configuration with id and max_tokens.
         client: Bedrock runtime client.
         region: AWS region name.
-        adaptive_models: List of model IDs that use adaptive thinking
-            (temperature is deprecated for these models).
 
     Returns:
         dict: Standard model configuration.
@@ -254,12 +262,6 @@ def _build_standard_model_config(
         "model_id": model_config["id"],
         "stop": STOP_SEQUENCES,
     }
-
-    # Adaptive models (e.g. Opus 4.7) don't support the temperature parameter
-    if not adaptive_models or not _is_adaptive_model(
-        model_config["id"], adaptive_models
-    ):
-        config["temperature"] = MODEL_TEMPERATURE_DEFAULT
 
     logger.debug(
         "Standard model config built",
@@ -298,7 +300,6 @@ def _build_main_model_config(
             },
             "anthropic_beta": ["interleaved-thinking-2025-05-14"],
         }
-        config["temperature"] = MODEL_TEMPERATURE_REASONING
 
         logger.debug(
             "Reasoning enabled for main model",
@@ -332,10 +333,7 @@ def _build_adaptive_model_config(
     Returns:
         dict: Model configuration with adaptive thinking parameters if reasoning > 0.
     """
-    # Pass model ID as adaptive so temperature is omitted
-    config = _build_standard_model_config(
-        model_config, client, region, adaptive_models=[model_config["id"]]
-    )
+    config = _build_standard_model_config(model_config, client, region)
 
     if reasoning != 0:
         # Per-model effort_map takes precedence over the global default
@@ -416,13 +414,12 @@ def _initialize_bedrock_models(
         attack_tree_config = _build_config_for_model(configs.attack_tree_model)
         version_config = _build_config_for_model(configs.version_model)
         version_diff_config = _build_config_for_model(configs.version_model)
-        adaptive = configs.adaptive_thinking_models
 
         struct_config = _build_standard_model_config(
-            configs.struct_model, client, region, adaptive
+            configs.struct_model, client, region
         )
         summary_config = _build_standard_model_config(
-            configs.summary_model, client, region, adaptive
+            configs.summary_model, client, region
         )
 
         # Initialize models
@@ -468,48 +465,110 @@ def _initialize_bedrock_models(
         raise
 
 
+# How long a minted Mantle bearer token is trusted before re-minting. The token
+# is a SigV4-presigned URL, so its effective life is bounded by the signing role
+# credentials (~1h on AgentCore) — re-mint well inside that window.
+MANTLE_TOKEN_TTL_SECONDS = 1800
+
+
+# One token cache per region, shared by every model built in this process. The
+# token is a property of the runtime role, not of a model, and initialize_models
+# builds 11 clients per run — a cache per closure meant 11 independent SigV4
+# mints and 11 independent re-mint clocks. Guarded by a lock because workflow
+# nodes invoke models from worker threads.
+_MANTLE_TOKEN_CACHES: Dict[str, Dict[str, Any]] = {}
+_MANTLE_TOKEN_LOCK = threading.Lock()
+
+
+def _mantle_token_provider(region: str):
+    """A callable returning a fresh Bedrock Mantle bearer token, cached briefly.
+
+    langchain_openai accepts ``api_key`` as a callable and invokes it per
+    request, so a long run keeps re-reading a currently-valid token minted from
+    whatever role credentials the default chain currently holds.
+    """
+    from aws_bedrock_token_generator import provide_token
+
+    with _MANTLE_TOKEN_LOCK:
+        cache = _MANTLE_TOKEN_CACHES.setdefault(region, {"token": None, "exp": 0.0})
+
+    def _provider() -> str:
+        with _MANTLE_TOKEN_LOCK:
+            now = time.time()
+            if cache["token"] is None or now >= cache["exp"]:
+                cache["token"] = provide_token(region=region)
+                cache["exp"] = now + MANTLE_TOKEN_TTL_SECONDS
+            return cache["token"]
+
+    return _provider
+
+
 def _create_openai_model(
     model_config: ModelConfig,
     reasoning: int,
     reasoning_effort_map: dict = None,
+    safety_id: str = "",
 ) -> Any:
     """
-    Create a single OpenAI model instance.
+    Create a single OpenAI GPT model instance.
+
+    Depending on MODEL_PROVIDER the model is served either directly by OpenAI
+    (API-key auth) or by the Bedrock Mantle OpenAI-compatible endpoint
+    (SigV4 bearer-token auth, model ID prefixed with "openai.").
 
     Args:
         model_config: Model configuration with id, max_tokens, and optional reasoning_effort map.
         reasoning: Reasoning level (0-4).
         reasoning_effort_map: Optional dict mapping reasoning levels to effort strings. If not provided, uses model_config.
+        safety_id: Stable per-user hash for OpenAI's safety_identifier, which
+            reduces false-positive trips of the cyber/bio misuse classifiers on
+            legitimate threat-modeling work. Omitted when empty.
 
     Returns:
         ChatOpenAI: Configured OpenAI model instance.
 
     Raises:
-        OpenAIAuthenticationError: If API key is missing.
+        OpenAIAuthenticationError: If API key is missing (direct OpenAI only).
     """
-    api_key = os.environ.get(ENV_OPENAI_API_KEY)
-    if not api_key:
-        raise OpenAIAuthenticationError("OPENAI_API_KEY environment variable not set")
+    provider = os.environ.get(ENV_MODEL_PROVIDER, MODEL_PROVIDER_BEDROCK)
+    use_mantle = provider == MODEL_PROVIDER_BEDROCK_MANTLE
 
     model_id = model_config["id"]
     max_tokens = model_config["max_tokens"]
 
     # Validate model ID against known GPT-5 family models
-    if model_id not in OPENAI_GPT5_FAMILY_MODELS:
+    if model_id.removeprefix(MANTLE_MODEL_PREFIX) not in OPENAI_GPT5_FAMILY_MODELS:
         logger.warning(
             "Model ID not in known GPT-5 family models",
             model_id=model_id,
             known_models=OPENAI_GPT5_FAMILY_MODELS,
         )
 
-    # Base configuration
+    # Base configuration. No temperature: the whole GPT-5 family rejects the
+    # parameter outright ("Unsupported parameter: 'temperature' is not supported
+    # with this model", HTTP 400) — including the summary/struct models that run
+    # with no reasoning config at all. Reasoning models don't honor a pinned
+    # sampling temperature anyway.
     config = {
         "model": model_id,
         "max_tokens": max_tokens,
-        "temperature": MODEL_TEMPERATURE_DEFAULT,
-        "api_key": api_key,
         "use_responses_api": True,
     }
+
+    if use_mantle:
+        mantle_region = os.environ.get(ENV_MANTLE_REGION, DEFAULT_MANTLE_REGION)
+        if not model_id.startswith(MANTLE_MODEL_PREFIX):
+            config["model"] = f"{MANTLE_MODEL_PREFIX}{model_id}"
+        config["base_url"] = f"https://bedrock-mantle.{mantle_region}.api.aws/openai/v1"
+        # Bearer token minted from the runtime role's credentials — no API key.
+        config["api_key"] = _mantle_token_provider(mantle_region)
+    else:
+        api_key = os.environ.get(ENV_OPENAI_API_KEY)
+        if not api_key:
+            raise OpenAIAuthenticationError(
+                "OPENAI_API_KEY environment variable not set"
+            )
+        config["api_key"] = api_key
 
     # Add reasoning effort if applicable
     effort_map = reasoning_effort_map or model_config.get("reasoning_effort", {})
@@ -547,12 +606,29 @@ def _create_openai_model(
             reasoning_effort=reasoning_effort,
         )
 
+    # Attributes traffic per end user so the provider's real-time cyber
+    # classifier is less likely to flag legitimate threat-modeling requests.
+    # Accepted by both direct OpenAI and the Bedrock Mantle endpoint.
+    if safety_id:
+        config["model_kwargs"] = {"safety_identifier": safety_id}
+
+    if "reasoning" in config:
+        # output_version is what puts the reasoning summary into the message
+        # content blocks ({"type": "reasoning", "summary": [...]}) where
+        # model_service.extract_reasoning_content reads it — without it the
+        # summary lands in additional_kwargs and never surfaces. Both GPT
+        # transports go through the same ChatOpenAI Responses API, so this is
+        # not Mantle-specific: gating it on Mantle left direct-OpenAI deploys
+        # writing an empty reasoning trail for every stage.
+        config["output_version"] = "responses/v1"
+
     return ChatOpenAI(**config)
 
 
 def _initialize_openai_models(
     reasoning: int = 0,
     job_id: Optional[str] = None,
+    safety_id: str = "",
 ) -> Dict[str, Any]:
     """
     Initialize OpenAI model clients with GPT-5 family.
@@ -575,17 +651,21 @@ def _initialize_openai_models(
         )
 
     try:
+        provider = os.environ.get(ENV_MODEL_PROVIDER, MODEL_PROVIDER_BEDROCK)
         logger.debug(
-            "Initializing OpenAI models",
+            "Initializing OpenAI GPT models",
             reasoning_level=reasoning,
+            provider=provider,
         )
 
-        # Validate API key
-        api_key = os.environ.get(ENV_OPENAI_API_KEY)
-        if not api_key:
-            raise OpenAIAuthenticationError(
-                "OPENAI_API_KEY environment variable not set"
-            )
+        # Validate API key (direct OpenAI only — Mantle auths with a SigV4
+        # bearer token minted from the runtime role's credentials)
+        if provider == MODEL_PROVIDER_OPENAI:
+            api_key = os.environ.get(ENV_OPENAI_API_KEY)
+            if not api_key:
+                raise OpenAIAuthenticationError(
+                    "OPENAI_API_KEY environment variable not set"
+                )
 
         # Load configurations
         logger.debug("Loading OpenAI model configurations from environment")
@@ -595,23 +675,23 @@ def _initialize_openai_models(
         logger.debug("Building OpenAI model configurations")
 
         models = {
-            "assets_model": _create_openai_model(configs.assets_model, reasoning),
-            "flows_model": _create_openai_model(configs.flows_model, reasoning),
-            "threats_model": _create_openai_model(configs.threats_model, reasoning),
+            "assets_model": _create_openai_model(configs.assets_model, reasoning, safety_id=safety_id),
+            "flows_model": _create_openai_model(configs.flows_model, reasoning, safety_id=safety_id),
+            "threats_model": _create_openai_model(configs.threats_model, reasoning, safety_id=safety_id),
             "threats_agent_model": _create_openai_model(
-                configs.threats_agent_model, reasoning
+                configs.threats_agent_model, reasoning, safety_id=safety_id
             ),
-            "gaps_model": _create_openai_model(configs.gaps_model, reasoning),
+            "gaps_model": _create_openai_model(configs.gaps_model, reasoning, safety_id=safety_id),
             "attack_tree_agent_model": _create_openai_model(
-                configs.attack_tree_model, reasoning
+                configs.attack_tree_model, reasoning, safety_id=safety_id
             ),
-            "version_model": _create_openai_model(configs.version_model, reasoning),
+            "version_model": _create_openai_model(configs.version_model, reasoning, safety_id=safety_id),
             "version_diff_model": _create_openai_model(
-                configs.version_model, reasoning
+                configs.version_model, reasoning, safety_id=safety_id
             ),
-            "struct_model": _create_openai_model(configs.struct_model, 0),
-            "summary_model": _create_openai_model(configs.summary_model, 0),
-            "space_context_model": _create_openai_model(configs.flows_model, reasoning),
+            "struct_model": _create_openai_model(configs.struct_model, 0, safety_id=safety_id),
+            "summary_model": _create_openai_model(configs.summary_model, 0, safety_id=safety_id),
+            "space_context_model": _create_openai_model(configs.flows_model, reasoning, safety_id=safety_id),
         }
 
         logger.debug(
@@ -646,6 +726,7 @@ def initialize_models(
     reasoning: int = 0,
     bedrock_client: Optional[boto3.client] = None,
     job_id: Optional[str] = None,
+    owner: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Initialize model clients based on configured provider.
@@ -657,6 +738,11 @@ def initialize_models(
         reasoning: Reasoning level (0-3). 0 disables/minimizes reasoning, 1-3 enables with different levels.
         bedrock_client: Optional pre-configured Bedrock client for testing (Bedrock only).
         job_id: Optional job ID for operation tracking.
+        owner: Optional end-user id (Cognito sub). Hashed into OpenAI's
+            safety_identifier so the provider can attribute traffic per user,
+            which reduces false-positive trips of its cyber/bio misuse
+            classifiers on legitimate threat-modeling requests. Ignored by the
+            Bedrock provider.
 
     Returns:
         Dict[str, Any]: Dictionary containing:
@@ -687,15 +773,20 @@ def initialize_models(
                 reasoning_level=reasoning,
             )
 
-            # Route to appropriate provider initialization
+            # Route to appropriate provider initialization. The Mantle
+            # provider serves the same GPT models as "openai" — only the
+            # transport/auth differs, handled inside _create_openai_model.
             if provider == MODEL_PROVIDER_BEDROCK:
                 return _initialize_bedrock_models(reasoning, bedrock_client, job_id)
-            elif provider == MODEL_PROVIDER_OPENAI:
-                return _initialize_openai_models(reasoning, job_id)
+            elif provider in (MODEL_PROVIDER_OPENAI, MODEL_PROVIDER_BEDROCK_MANTLE):
+                return _initialize_openai_models(
+                    reasoning, job_id, safety_identifier(owner)
+                )
             else:
                 raise ModelProviderError(
                     f"Unsupported model provider: {provider}. "
-                    f"Supported providers: {MODEL_PROVIDER_BEDROCK}, {MODEL_PROVIDER_OPENAI}"
+                    f"Supported providers: {MODEL_PROVIDER_BEDROCK}, "
+                    f"{MODEL_PROVIDER_OPENAI}, {MODEL_PROVIDER_BEDROCK_MANTLE}"
                 )
 
         except (ModelProviderError, OpenAIAuthenticationError):

--- a/backend/threat_designer/prompt_provider.py
+++ b/backend/threat_designer/prompt_provider.py
@@ -2,7 +2,7 @@
 
 import os
 
-from constants import MODEL_PROVIDER_BEDROCK, MODEL_PROVIDER_OPENAI
+from constants import MODEL_PROVIDER_BEDROCK, OPENAI_FAMILY_PROVIDERS
 
 # Resolve provider once at import time
 try:
@@ -12,7 +12,9 @@ try:
 except ImportError:
     _provider = os.environ.get("MODEL_PROVIDER", MODEL_PROVIDER_BEDROCK)
 
-if _provider == MODEL_PROVIDER_OPENAI:
+# GPT prompts apply to every provider that serves GPT models — direct OpenAI
+# and Bedrock Mantle alike; only the transport differs.
+if _provider in OPENAI_FAMILY_PROVIDERS:
     from prompts_gpt import (  # noqa: F401
         APPLICATION_TYPE_DESCRIPTIONS,
         asset_prompt,

--- a/backend/threat_designer/prompts.py
+++ b/backend/threat_designer/prompts.py
@@ -8,6 +8,11 @@ Each function generates specialized prompts for different phases of the threat m
 - Gap analysis
 - Threat identification and improvement
 - Response structuring
+
+This version is tuned for the Claude 5 family (Opus 5 / Sonnet 5): the models
+self-verify and self-correct, so the prompts avoid explicit verification and
+re-check instructions, and instead steer narration cadence explicitly since
+these models narrate agentic work readily.
 """
 
 import os
@@ -530,7 +535,7 @@ that puts it in scope.
 
 
 def structure_prompt(data) -> str:
-    return f"""You are an helpful assistant whose goal is to to convert the response from your colleague
+    return f"""You are a helpful assistant whose goal is to convert the response from your colleague
      to the desired structured output. The response is provided within <response> \n
      <response>
      {data}
@@ -618,6 +623,13 @@ flows_stats — current counts and contents. Call after each batch.
 
 Submit parallel add calls when you have items ready for multiple categories.
 </tools>
+
+<progress_updates>
+Before your first tool call, say in one sentence what you're about to do. While
+working, give a brief update (1-2 sentences) only when you complete a category
+or a discovery changes your plan — each update names a concrete outcome. Do not
+narrate routine tool calls.
+</progress_updates>
 
 <workflow>
 Work in iterative cycles: define a batch → flows_stats → identify gaps → next
@@ -752,6 +764,13 @@ catalog_stats — check {label} distribution and asset coverage.
 read_threat_catalog — review current catalog before adding or after gap_analysis.
 </tools>
 
+<progress_updates>
+Before your first tool call, say in one sentence what you're about to do. While
+working, give a brief update (1-2 sentences) only when you complete an analysis
+group or a gap_analysis result changes your plan — each update names a concrete
+outcome. Do not narrate routine tool calls.
+</progress_updates>
+
 <workflow>
 Work in a generate → audit → fix cycle.
 
@@ -764,7 +783,7 @@ Expand from there across remaining assets and {label} coverage through
 additional batched add_threats calls. Maximize each batch — larger batches
 mean fewer round-trips and faster completion.
 
-After ~25-30 accumulated threats, call `gap_analysis`.. Weigh findings against your
+After ~25-30 accumulated threats, call `gap_analysis`. Weigh findings against your
 own assessment — address genuine gaps, use judgment on marginal ones. If
 gap_analysis repeatedly flags something you've already evaluated and rejected,
 note your reasoning and move on.

--- a/backend/threat_designer/prompts_gpt.py
+++ b/backend/threat_designer/prompts_gpt.py
@@ -1,5 +1,5 @@
 """
-Threat Modeling Prompt Generation Module — GPT 5.2 Optimized
+Threat Modeling Prompt Generation Module — GPT-5.6 Optimized
 
 This module provides a collection of functions for generating prompts used in security threat modeling analysis.
 Each function generates specialized prompts for different phases of the threat modeling process, including:
@@ -9,8 +9,10 @@ Each function generates specialized prompts for different phases of the threat m
 - Threat identification and improvement
 - Response structuring
 
-This version is optimized for OpenAI GPT 5.2's instruction-following characteristics:
-stronger adherence, lower drift, conservative grounding bias, and native tool parallelism.
+This version is tuned for GPT-5.6 (Sol/Terra/Luna): leaner prompts perform
+better on this family, so each instruction is stated once, self-check
+scaffolding written for older models is removed, and persistence guidance is
+kept explicit because the workflow runs unattended (no user in the loop).
 """
 
 import os
@@ -136,13 +138,6 @@ Criticality: [Low | Medium | High]
 
 Group all Assets first, then all Entities. Order each group by criticality (High first).
 </output_format>
-
-<high_risk_self_check>
-Before finalizing, re-scan:
-- Every item traces to a real component in the inputs (no hallucinated components).
-- No duplicate entries.
-- Criticality assignments are consistent with the criteria above.
-</high_risk_self_check>
 """
     return [{"type": "text", "text": app_type_context + main_prompt}]
 
@@ -217,16 +212,6 @@ Commit to your decision. Minor calibration quibbles are a STOP — reserve CONTI
 - Do NOT fabricate threat IDs or reference threats absent from the catalog.
 - If ambiguous, choose the simplest valid interpretation.
 - Never soften a CONTINUE into a STOP to avoid conflict — accuracy over diplomacy.
-
----
-
-# Self-Check (required before finalizing)
-
-Before producing your final output, re-scan your draft for:
-1. Any compliance finding that references a component not explicitly in the architecture — remove it.
-2. Any coverage gap that is reasonably out of scope for this architecture — remove it.
-3. Any priority action that is vague or non-actionable — rewrite with a specific component and imperative verb.
-4. Verify your STOP/CONTINUE decision is consistent with your verdicts (any FAIL = CONTINUE).
 
 ---
 
@@ -350,16 +335,6 @@ Return a JSON array of threat objects. Each object must conform to this schema:
 
 Do not wrap the JSON in markdown code fences. Output only the JSON array.
 </output_format>
-
-<high_risk_self_check>
-Before finalizing, re-scan:
-- Every target matches a real component name from the architecture inputs.
-- Every source matches a real threat_source identifier.
-- No threat contradicts a stated assumption.
-- Description sentence structure matches the required template.
-- No duplicate threats relative to the existing catalog.
-- Likelihood and impact ratings follow the calibration rules.
-</high_risk_self_check>
 """
 
     if instructions:
@@ -465,7 +440,7 @@ def create_space_context_system_prompt() -> SystemMessage:
     - When relevant queries are exhausted or budget is spent, stop immediately. No summary, no closing statement.
     </output_rules>
     """
-    # GPT 5.2: caching is handled automatically by OpenAI
+    # GPT-5.6: implicit prompt caching is handled automatically by OpenAI
     return SystemMessage(content=prompt)
 
 
@@ -538,6 +513,8 @@ def create_flows_agent_system_prompt(
 
 You are a security architect operating as an autonomous flow definition agent. You analyze system architectures to identify data flows, trust boundaries, and threat actors, building a comprehensive FlowsList through iterative tool calls.
 
+This workflow runs unattended — there is no user available to answer questions. Keep going until the FlowsList is complete before ending your turn. When something is ambiguous, choose the most reasonable architecture-grounded interpretation and proceed.
+
 ---
 
 # Scope Constraints
@@ -561,15 +538,6 @@ The user provides four inputs — use all of them together to build a holistic u
 2. **System description** — the system's purpose and design.
 3. **Assumptions** — deployment and security posture constraints.
 4. **Asset/entity inventory** — previously identified assets and entities (the authoritative source for all entity names).
-
----
-
-# Long-Context Handling
-
-When processing the combined inputs:
-- First produce a short internal outline of security-critical components and their relationships.
-- Re-state the inventory's entity names explicitly before making tool calls — these are the only valid values for `source_entity` and `target_entity`.
-- Anchor each flow or boundary to a specific element from the inputs ("Per the architecture diagram, the API Gateway forwards to…") rather than generically.
 
 ---
 
@@ -646,13 +614,9 @@ Identify threat actors who could realistically compromise the system within the 
 
 ---
 
-# Completeness & Self-Check
+# Completion Criteria
 
-Before considering the FlowsList complete:
-1. Call `flows_stats` and verify every asset and entity from the inventory appears in at least one data flow or trust boundary. Items with no security-relevant flows are acceptable but should be the exception.
-2. Confirm at least 4 threat sources are defined.
-3. Re-scan for any `source_entity` or `target_entity` value that does not exactly match the inventory — correct or delete before finishing.
-4. Verify no flows or boundaries reference components you inferred but that are not explicitly present in the inputs.
+The FlowsList is complete when `flows_stats` shows: every asset and entity from the inventory appears in at least one data flow or trust boundary (items with no security-relevant interactions are acceptable exceptions), and at least 4 threat sources are defined.
     """
 
     prompt += (
@@ -665,7 +629,7 @@ Before considering the FlowsList complete:
             f"\n\n<additional_instructions>\n{instructions}\n</additional_instructions>"
         )
 
-    # GPT 5.2: caching is handled automatically by OpenAI — no manual cache points needed
+    # GPT-5.6: implicit prompt caching is handled automatically by OpenAI — no manual cache points needed
     return SystemMessage(content=prompt)
 
 
@@ -683,6 +647,8 @@ def create_threats_agent_system_prompt(
     prompt = f"""# Role
 
 You are a security architect performing threat modeling for a system architecture. You build a comprehensive threat catalog. {methodology_role_directive(methodology)}
+
+This workflow runs unattended — there is no user available to answer questions. Keep going until the catalog is complete before ending your turn. When something is ambiguous, choose the most reasonable architecture-grounded interpretation and proceed.
 
 ---
 
@@ -720,7 +686,7 @@ Assumptions are guardrails, not attack surface. If the architecture states "all 
 
 ## Target Specificity
 
-Every `target` names a single, specific component exactly as it appears in the architecture — "Orders API", not "The System."
+Every `target` names a single, specific component exactly as it appears in the architecture — "Orders API", not "The System." Both `target` and `source` must exactly match enum values from the `add_threats` tool schema; copy them verbatim, as mismatches are rejected.
 
 ## Description Format
 
@@ -794,16 +760,6 @@ Add missing threats, delete or replace miscalibrated ones. Run `catalog_stats` t
 When the catalog has solid {label} coverage across all assets, trust boundaries, and data flows — or `gap_analysis` returns no critical/high findings — output **`THREAT_CATALOG_COMPLETE`** as your final message.
 
 Commit to calibration decisions. Revisit likelihood/impact only when `gap_analysis` explicitly flags them.
-
----
-
-# Completion Self-Check
-
-Before outputting `THREAT_CATALOG_COMPLETE`, verify:
-1. Every asset appears as a `target` in at least one threat.
-2. Every applicable {label} is reasonably represented — none is absent without justification.
-3. No threat contradicts a stated architecture assumption.
-4. All `target` and `source` values exactly match the tool schema enums.
 
 {app_type_context}
 {criticality_context}

--- a/backend/threat_designer/requirements.txt
+++ b/backend/threat_designer/requirements.txt
@@ -1,6 +1,12 @@
 langgraph>=1.2.4,<1.3.0
-langchain-aws==1.4.3
+langchain-aws==1.6.4
 langchain-openai==1.1.14
+# Mints the SigV4-derived bearer token for GPT models on Bedrock Mantle.
+# Pinned like every other dep here: there is no lock file, so any rebuild
+# re-resolves, and a 2.x that moves or renames provide_token would break
+# _mantle_token_provider's import at container start — taking down all Mantle
+# auth at runtime.
+aws-bedrock-token-generator==1.1.0
 langchain==1.3.9
 uv==0.11.15
 uvicorn[standard]==0.37.0

--- a/backend/threat_designer/workflow_attack_tree.py
+++ b/backend/threat_designer/workflow_attack_tree.py
@@ -27,6 +27,41 @@ from langgraph.graph import MessagesState
 from constants import MAX_EXECUTION_TIME_SECONDS
 
 
+# Stop reasons that mean the provider suppressed the response rather than the
+# model choosing to stop. Bedrock reports these in response_metadata["stopReason"],
+# the OpenAI family in response_metadata["finish_reason"].
+FILTERED_STOP_REASONS = frozenset(
+    {"content_filtered", "guardrail_intervened", "content_filter"}
+)
+
+
+def _filtered_stop_reason(response: object) -> Optional[str]:
+    """
+    Return the stop reason if the provider filtered the response, else None.
+
+    Enumerating concrete attack techniques for a target reads as dual-use to
+    provider safety layers, so an attack-tree turn can come back suppressed. The
+    costly part is that it comes back with HTTP 200 and an EMPTY body: no text and
+    no tool calls. The agent then looks "done", the continue node finds no tree and
+    nudges it to try again, and the graph spins agent -> continue -> agent until it
+    trips recursion_limit — dozens of full-price calls, and a failure whose logs say
+    nothing about the cause. Detecting the stop reason turns that into one clear
+    error.
+
+    Args:
+        response: Message returned by the bound model
+
+    Returns:
+        Optional[str]: The filtering stop reason, or None if the turn was normal
+    """
+    metadata = getattr(response, "response_metadata", None) or {}
+    for key in ("stopReason", "finish_reason"):
+        reason = metadata.get(key)
+        if isinstance(reason, str) and reason.lower() in FILTERED_STOP_REASONS:
+            return reason
+    return None
+
+
 # ============================================================================
 # State Definition
 # ============================================================================
@@ -153,7 +188,7 @@ def agent_node(state: AttackTreeState, config: RunnableConfig) -> Command:
     start_time = state.get("start_time")
 
     try:
-        # Check for timeout (5 minutes max)
+        # Check for timeout
         if start_time:
             elapsed_time = time.time() - start_time
             if elapsed_time > MAX_EXECUTION_TIME_SECONDS:
@@ -163,10 +198,22 @@ def agent_node(state: AttackTreeState, config: RunnableConfig) -> Command:
                     attack_tree_id=attack_tree_id,
                     elapsed_time=elapsed_time,
                     max_time=MAX_EXECUTION_TIME_SECONDS,
+                    tool_use=tool_use,
+                    validate_tool_use=validate_tool_use,
                 )
-                # Update status to failed
+                # Update status to failed. Every other failure path here records a
+                # detail; without one a timeout is indistinguishable in the UI from
+                # any other failure, which is the hardest kind to diagnose.
                 try:
-                    state_service.update_job_state(attack_tree_id, "failed")
+                    state_service.update_job_state(
+                        attack_tree_id,
+                        "failed",
+                        detail=(
+                            "Attack tree generation timed out after "
+                            f"{int(elapsed_time)}s (limit {MAX_EXECUTION_TIME_SECONDS}s) "
+                            f"with {tool_use} tool calls."
+                        ),
+                    )
                 except Exception as status_error:
                     logger.error(
                         "Failed to update status to failed after timeout",
@@ -562,6 +609,53 @@ def agent_node(state: AttackTreeState, config: RunnableConfig) -> Command:
                     error=str(status_error),
                 )
             raise RuntimeError(f"Model invocation failed: {str(e)}")
+
+        # A suppressed turn returns HTTP 200 with an empty body, so it has to be
+        # detected explicitly or the graph spins until recursion_limit. Fail here
+        # instead, with the stop reason in the job detail.
+        stop_reason = _filtered_stop_reason(response)
+        if stop_reason:
+            logger.error(
+                "Model response suppressed by the provider's safety layer",
+                node="agent",
+                attack_tree_id=attack_tree_id,
+                stop_reason=stop_reason,
+                model_type=type(model).__name__,
+                has_tool_calls=bool(getattr(response, "tool_calls", None)),
+            )
+            try:
+                state_service.update_job_state(
+                    attack_tree_id,
+                    "failed",
+                    detail=(
+                        "The model provider suppressed the attack tree response "
+                        f"(stop reason: {stop_reason}). Retry, or generate the tree "
+                        "for a more narrowly scoped threat."
+                    ),
+                )
+            except Exception as status_error:
+                logger.error(
+                    "Failed to update status to failed after filtered response",
+                    node="agent",
+                    attack_tree_id=attack_tree_id,
+                    error=str(status_error),
+                )
+            raise RuntimeError(
+                f"Attack tree response was filtered by the provider ({stop_reason})"
+            )
+
+        # Log the stop reason so a stalled run is diagnosable from the logs alone
+        logger.debug(
+            "Model turn completed",
+            node="agent",
+            attack_tree_id=attack_tree_id,
+            stop_reason=(getattr(response, "response_metadata", None) or {}).get(
+                "stopReason"
+            )
+            or (getattr(response, "response_metadata", None) or {}).get(
+                "finish_reason"
+            ),
+        )
 
         # Update status based on tool calls
         if hasattr(response, "tool_calls") and response.tool_calls:

--- a/cli/threat_designer_cli/commands/run_cmd.py
+++ b/cli/threat_designer_cli/commands/run_cmd.py
@@ -34,11 +34,13 @@ from ..styles import (
     fmt_duration,
 )
 
-_EFFORT_CHOICES = ["off", "low", "medium", "high", "xhigh", "max"]
+# The ladder tops out at "xhigh": no catalog effort_map maps a level to "max",
+# so offering it here only produced "Model does not support effort 'max'".
+_EFFORT_CHOICES = ["low", "medium", "high", "xhigh"]
 
 
 def _effort_to_level(effort: str, model_props: dict | None) -> int:
-    """Resolve a CLI effort string (off/low/.../max) to the reasoning level for this model."""
+    """Resolve a CLI effort string (low/.../max) to the reasoning level for this model."""
     for lvl in reasoning_levels_for_model(model_props):
         if lvl["effort"] == effort:
             return lvl["value"]
@@ -74,7 +76,7 @@ def _parse_args(argv: list) -> argparse.Namespace:
         "--effort",
         choices=_EFFORT_CHOICES,
         default=None,
-        help="Override configured effort level (off/low/medium/high/xhigh/max — availability varies by model)",
+        help="Override configured effort level (low/medium/high/xhigh — availability varies by model)",
     )
     p.add_argument(
         "--iterations",

--- a/cli/threat_designer_cli/config.py
+++ b/cli/threat_designer_cli/config.py
@@ -15,9 +15,9 @@ class CLIConfig(BaseModel):
     provider: str = "bedrock"
     aws_profile: Optional[str] = None
     aws_region: str = "us-west-2"
-    model_id: str = "us.anthropic.claude-sonnet-4-6-20251101-v1:0"
-    model_name: str = "Claude Sonnet 4.6 (Balanced)"
-    reasoning_level: int = 0
+    model_id: str = "global.anthropic.claude-sonnet-5"
+    model_name: str = "Claude Sonnet 5 (Balanced)"
+    reasoning_level: int = 1
     openai_api_key: Optional[str] = None
 
     @classmethod

--- a/cli/threat_designer_cli/models.py
+++ b/cli/threat_designer_cli/models.py
@@ -2,8 +2,8 @@
 
 BEDROCK_MODELS = [
     {
-        "name": "Claude Opus 4.7 (Most Capable)",
-        "id": "global.anthropic.claude-opus-4-7",
+        "name": "Claude Opus 5 (Most Capable)",
+        "id": "global.anthropic.claude-opus-5",
         "max_tokens": 128000,
         "adaptive": True,
         "supports_max": True,
@@ -12,51 +12,78 @@ BEDROCK_MODELS = [
             "2": "medium",
             "3": "high",
             "4": "xhigh",
-            "5": "max",
         },
     },
     {
-        "name": "Claude Opus 4.6",
-        "id": "global.anthropic.claude-opus-4-6-v1",
-        "max_tokens": 32000,
+        "name": "Claude Sonnet 5 (Balanced)",
+        "id": "global.anthropic.claude-sonnet-5",
+        "max_tokens": 128000,
         "adaptive": True,
         "supports_max": True,
-    },
-    {
-        "name": "Claude Sonnet 4.6 (Balanced)",
-        "id": "global.anthropic.claude-sonnet-4-6",
-        "max_tokens": 32000,
-        "adaptive": True,
-        "supports_max": True,
+        "effort_map": {
+            "1": "low",
+            "2": "medium",
+            "3": "high",
+            "4": "xhigh",
+        },
     },
 ]
 
+# GPT-5.6 fleet: Sol is the flagship (the "gpt-5.6" alias routes to it),
+# Terra balances intelligence and cost, Luna serves efficient high-volume work.
+# All three accept the full reasoning-effort ladder; level 4 tops out at
+# "xhigh" (recommended for agentic work) rather than the pricier "max".
 OPENAI_MODELS = [
     {
-        "name": "GPT-5.4 (Latest)",
-        "id": "gpt-5.4-2026-03-05",
+        "name": "GPT-5.6 Sol (Most Capable)",
+        "id": "gpt-5.6-sol",
         "max_tokens": 32000,
-        "mini": False,
-        "effort_map": {"1": "low", "2": "medium", "3": "high", "4": "xhigh"},
+        "effort_map": {
+            "1": "low",
+            "2": "medium",
+            "3": "high",
+            "4": "xhigh",
+        },
+    },
+    {
+        "name": "GPT-5.6 Terra (Balanced)",
+        "id": "gpt-5.6-terra",
+        "max_tokens": 32000,
+        "effort_map": {
+            "1": "low",
+            "2": "medium",
+            "3": "high",
+            "4": "xhigh",
+        },
+    },
+    {
+        "name": "GPT-5.6 Luna (Efficient)",
+        "id": "gpt-5.6-luna",
+        "max_tokens": 32000,
+        "effort_map": {
+            "1": "low",
+            "2": "medium",
+            "3": "high",
+            "4": "xhigh",
+        },
     },
 ]
 
-# Effort levels — map int value → display label
+# Effort levels — map int value → display label. Levels start at 1: every
+# current model is a reasoning model, so there is no 'off' level.
 REASONING_LEVELS = [
-    {"name": "Off  — no reasoning", "value": 0, "effort": "off"},
     {"name": "Low", "value": 1, "effort": "low"},
     {"name": "Medium", "value": 2, "effort": "medium"},
     {"name": "High", "value": 3, "effort": "high"},
-    {"name": "Max  — most thorough", "value": 4, "effort": "max"},
+    {"name": "Extra High  — most thorough", "value": 4, "effort": "xhigh"},
 ]
 
 # Display names for effort strings
 _EFFORT_DISPLAY = {
-    "off": "Off",
     "low": "Low",
     "medium": "Medium",
     "high": "High",
-    "xhigh": "xHigh",
+    "xhigh": "Extra High",
     "max": "Max",
 }
 
@@ -70,7 +97,7 @@ def reasoning_levels_for_model(model_props: dict | None = None) -> list[dict]:
         return REASONING_LEVELS
     effort_map = model_props["effort_map"]
     max_level = max(int(k) for k in effort_map)
-    levels = [REASONING_LEVELS[0]]  # "Off" is always the same
+    levels = []
     for i in range(1, max_level + 1):
         effort = effort_map.get(str(i), "low")
         display = _EFFORT_DISPLAY.get(effort, effort)

--- a/cli/threat_designer_cli/runner/model_factory.py
+++ b/cli/threat_designer_cli/runner/model_factory.py
@@ -14,14 +14,16 @@ from botocore.config import Config as BotoConfig
 from langchain_aws import ChatBedrockConverse
 
 
-# OpenAI Responses API accepts minimal/low/medium/high. "xhigh"/"max" clamp to "high".
+# GPT-5.6 accepts none/low/medium/high/xhigh/max and REJECTS "minimal" with a
+# 400 (it was removed from the family), so these pass straight through. Clamping
+# xhigh down to high also silently threw away the top of the ladder.
 _OPENAI_EFFORT_MAP = {
     "off": None,
-    "low": "minimal",
+    "low": "low",
     "medium": "medium",
     "high": "high",
-    "xhigh": "high",
-    "max": "high",
+    "xhigh": "xhigh",
+    "max": "max",
 }
 
 

--- a/cli/threat_designer_cli/runner/pipeline.py
+++ b/cli/threat_designer_cli/runner/pipeline.py
@@ -1615,7 +1615,7 @@ _gap_on_result = None
 
 
 def build_agent(
-    model_id: str = "global.anthropic.claude-opus-4-6-v1",
+    model_id: str = "global.anthropic.claude-opus-5",
     region: str = "us-east-1",
     reasoning_effort: str = "medium",
     application_type: str = "hybrid",
@@ -1727,7 +1727,7 @@ def run_pipeline(
     image_path: str,
     description: str = "",
     assumptions: list[str] | None = None,
-    model_id: str = "global.anthropic.claude-opus-4-6-v1",
+    model_id: str = "global.anthropic.claude-opus-5",
     region: str = "us-east-1",
     reasoning_effort: str = "medium",
     application_type: str = "hybrid",

--- a/deployment.sh
+++ b/deployment.sh
@@ -7,6 +7,7 @@ set -e
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 # Function to check if .deployment.config exists and load variables
@@ -96,7 +97,8 @@ get_model_provider() {
     while true; do
         echo -e "${BLUE}Select AI model provider:${NC}"
         echo -e "1) Amazon Bedrock (Claude) ${GREEN}(default)${NC}"
-        echo "2) OpenAI (GPT-5)"
+        echo "2) OpenAI (GPT-5.6)"
+        echo "3) Amazon Bedrock Mantle (GPT-5.6, no OpenAI API key needed)"
         read -r choice
         if [ -z "$choice" ]; then
             MODEL_PROVIDER="bedrock"
@@ -105,7 +107,13 @@ get_model_provider() {
         case $choice in
             1) MODEL_PROVIDER="bedrock"; break;;
             2) MODEL_PROVIDER="openai"; break;;
-            *) echo -e "${RED}Invalid choice. Please select 1 or 2${NC}";;
+            3) MODEL_PROVIDER="bedrock-mantle"
+               echo ""
+               echo -e "${YELLOW}Warning: GPT models on Bedrock Mantle are only served from US regions.${NC}"
+               echo -e "${YELLOW}Model inference is locked to us-east-2, regardless of the region you deploy to.${NC}"
+               echo ""
+               break;;
+            *) echo -e "${RED}Invalid choice. Please select 1, 2 or 3${NC}";;
         esac
     done
 }
@@ -139,9 +147,46 @@ get_openai_api_key() {
     done
 }
 
-# Function to get Tavily API key (optional)
+# Function to choose the web search provider for Sentry (optional feature)
+get_web_search_provider() {
+    while true; do
+        echo -e "${BLUE}Select web search provider for Sentry:${NC}"
+        echo -e "1) None ${GREEN}(default)${NC}"
+        echo "2) Tavily (search + page extraction, requires an API key)"
+        echo "3) Amazon Bedrock AgentCore (search only, no API key needed)"
+        read -r choice
+        if [ -z "$choice" ]; then
+            WEB_SEARCH_PROVIDER="none"
+            break
+        fi
+        case $choice in
+            1) WEB_SEARCH_PROVIDER="none"; break;;
+            2) WEB_SEARCH_PROVIDER="tavily"
+               get_tavily_api_key
+               # An empty key leaves the tools unavailable at runtime, so fall
+               # back rather than deploying a provider that can't work.
+               if [ -z "$TAVILY_API_KEY" ]; then
+                   echo -e "${YELLOW}No Tavily API key provided - web search disabled.${NC}"
+                   WEB_SEARCH_PROVIDER="none"
+               fi
+               break;;
+            3) WEB_SEARCH_PROVIDER="agentcore"
+               echo ""
+               echo -e "${YELLOW}Note: the web search gateway is created in us-east-1 by default.${NC}"
+               echo -e "${YELLOW}The connector is only offered in us-east-1, eu-west-1 and${NC}"
+               echo -e "${YELLOW}ap-northeast-1 — to use another, change the 'web_search_region'${NC}"
+               echo -e "${YELLOW}variable in infra/variables.tf. This may differ from your${NC}"
+               echo -e "${YELLOW}deployment region; queries stay inside AWS either way.${NC}"
+               echo ""
+               break;;
+            *) echo -e "${RED}Invalid choice. Please select 1, 2 or 3${NC}";;
+        esac
+    done
+}
+
+# Function to get Tavily API key
 get_tavily_api_key() {
-    echo -e "${BLUE}Enter your Tavily API key (optional, press Enter to skip):${NC}"
+    echo -e "${BLUE}Enter your Tavily API key (press Enter to skip):${NC}"
     echo -e "${BLUE}(Enables web search and content extraction in Sentry assistant)${NC}"
     read -rs TAVILY_API_KEY  # -s flag hides input
     echo ""  # New line after hidden input
@@ -241,9 +286,9 @@ if [ "$USE_EXISTING" = false ]; then
                 get_openai_api_key
             fi
             
-            # Get Tavily API key (optional, for web search in Sentry)
+            # Choose the web search provider (optional, for Sentry)
             if [ "$ENABLE_SENTRY" = "true" ]; then
-                get_tavily_api_key
+                get_web_search_provider
             fi
             
             # Get user inputs
@@ -270,11 +315,15 @@ if [ "$USE_EXISTING" = false ]; then
             if [ "$MODEL_PROVIDER" = "openai" ]; then
                 echo -e "OpenAI API Key: ${BLUE}****** (hidden)${NC}"
             fi
+            if [ "$MODEL_PROVIDER" = "bedrock-mantle" ]; then
+                echo -e "Mantle Inference Region: ${YELLOW}us-east-2 (US-locked)${NC}"
+            fi
             echo -e "Sentry Enabled: ${BLUE}$ENABLE_SENTRY${NC}"
-            if [ "$ENABLE_SENTRY" = "true" ] && [ -n "$TAVILY_API_KEY" ]; then
-                echo -e "Tavily API Key: ${BLUE}****** (hidden)${NC}"
-            elif [ "$ENABLE_SENTRY" = "true" ]; then
-                echo -e "Tavily API Key: ${BLUE}(not configured)${NC}"
+            if [ "$ENABLE_SENTRY" = "true" ]; then
+                echo -e "Web Search: ${BLUE}${WEB_SEARCH_PROVIDER:-none}${NC}"
+                if [ "$WEB_SEARCH_PROVIDER" = "tavily" ]; then
+                    echo -e "Tavily API Key: ${BLUE}****** (hidden)${NC}"
+                fi
             fi
             echo -e "Username: ${BLUE}$USERNAME${NC}"
             echo -e "Given Name: ${BLUE}$GIVEN_NAME${NC}"
@@ -316,9 +365,9 @@ else
             get_openai_api_key
         fi
         
-        # Get Tavily API key (optional, for web search in Sentry)
+        # Choose the web search provider (optional, for Sentry)
         if [ "$ENABLE_SENTRY" = "true" ]; then
-            get_tavily_api_key
+            get_web_search_provider
         fi
     fi
 fi
@@ -369,6 +418,9 @@ deploy_backend() {
         TF_VARS="$TF_VARS -var=openai_api_key=$OPENAI_API_KEY"
     fi
     
+    # Web search provider for Sentry (none / tavily / agentcore)
+    TF_VARS="$TF_VARS -var=web_search_provider=${WEB_SEARCH_PROVIDER:-none}"
+
     # Add Tavily API key if provided
     if [ -n "$TAVILY_API_KEY" ]; then
         TF_VARS="$TF_VARS -var=tavily_api_key=$TAVILY_API_KEY"

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -102,35 +102,38 @@ export async function installApiMocks(page: Page, overrides: ApiOverrides = {}) 
   await page.route(new RegExp(`^${API}/spaces/[^/]+/share(\\?.*)?$`), (route) =>
     route.fulfill({ json: { shared: [] } })
   );
-  await page.route(
-    new RegExp(`^${API}/spaces/[^/]+/documents(/[^/?]+)?(\\?.*)?$`),
-    (route) => {
-      const method = route.request().method();
-      // POST /documents/upload -> presigned response
-      if (method === "POST" && /\/documents\/upload/.test(route.request().url())) {
-        return route.fulfill({
-          json: {
-            document_id: "doc-new-1",
-            presigned_url: `${S3}/space-upload`,
-            s3_key: "space/new-key",
-          },
-        });
-      }
-      // POST /documents/confirm -> ingestion started
-      if (method === "POST" && /\/documents\/confirm/.test(route.request().url())) {
-        return route.fulfill({
-          json: {
-            document_id: "doc-new-1",
-            filename: "space-doc.pdf",
-            status: "INGESTING",
-          },
-        });
-      }
-      if (method === "DELETE") return route.fulfill({ json: { ok: true } });
-      // GET /documents
-      return route.fulfill({ json: { documents: (overrides.spaceDetail as { documents?: unknown[] } | undefined)?.documents ?? (spaceDetail as { documents: unknown[] }).documents } });
+  await page.route(new RegExp(`^${API}/spaces/[^/]+/documents(/[^/?]+)?(\\?.*)?$`), (route) => {
+    const method = route.request().method();
+    // POST /documents/upload -> presigned response
+    if (method === "POST" && /\/documents\/upload/.test(route.request().url())) {
+      return route.fulfill({
+        json: {
+          document_id: "doc-new-1",
+          presigned_url: `${S3}/space-upload`,
+          s3_key: "space/new-key",
+        },
+      });
     }
-  );
+    // POST /documents/confirm -> ingestion started
+    if (method === "POST" && /\/documents\/confirm/.test(route.request().url())) {
+      return route.fulfill({
+        json: {
+          document_id: "doc-new-1",
+          filename: "space-doc.pdf",
+          status: "INGESTING",
+        },
+      });
+    }
+    if (method === "DELETE") return route.fulfill({ json: { ok: true } });
+    // GET /documents
+    return route.fulfill({
+      json: {
+        documents:
+          (overrides.spaceDetail as { documents?: unknown[] } | undefined)?.documents ??
+          (spaceDetail as { documents: unknown[] }).documents,
+      },
+    });
+  });
 
   // 5) Generic /threat-designer/:id (GET / PUT / DELETE). Specific paths below override this.
   await page.route(new RegExp(`^${API}/threat-designer/[^/?]+(\\?.*)?$`), async (route) => {
@@ -168,7 +171,10 @@ export async function installApiMocks(page: Page, overrides: ApiOverrides = {}) 
     route.fulfill({ json: { presigned: `${S3}/upload-target`, name: "s3://mock/key.png" } })
   );
   await page.route(new RegExp(`^${API}/threat-designer/download(\\?.*)?$`), (route) =>
-    route.fulfill({ contentType: "application/json", body: JSON.stringify(`${S3}/download-target`) })
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(`${S3}/download-target`),
+    })
   );
   await page.route(new RegExp(`^${API}/threat-designer/download/batch(\\?.*)?$`), (route) =>
     route.fulfill({ json: { results: [] } })

--- a/e2e/fixtures/mocks/attack-tree.json
+++ b/e2e/fixtures/mocks/attack-tree.json
@@ -17,8 +17,6 @@
         "data": { "label": "SQL injection on API", "attackChainPhase": "Access" }
       }
     ],
-    "edges": [
-      { "id": "edge-1", "source": "goal-1", "target": "leaf-1" }
-    ]
+    "edges": [{ "id": "edge-1", "source": "goal-1", "target": "leaf-1" }]
   }
 }

--- a/e2e/fixtures/mocks/threat-model-complete.json
+++ b/e2e/fixtures/mocks/threat-model-complete.json
@@ -13,9 +13,7 @@
     "description": "Handles card payments.",
     "s3_location": "s3://mock/tm-1/architecture.png",
     "assets": {
-      "assets": [
-        { "id": "asset-1", "name": "Card details", "description": "PCI-sensitive data" }
-      ]
+      "assets": [{ "id": "asset-1", "name": "Card details", "description": "PCI-sensitive data" }]
     },
     "system_architecture": {
       "trust_boundaries": [{ "id": "tb-1", "name": "External" }],

--- a/e2e/fixtures/mocks/threat-model-shared-readonly.json
+++ b/e2e/fixtures/mocks/threat-model-shared-readonly.json
@@ -13,9 +13,7 @@
     "description": "Handles card payments.",
     "s3_location": "s3://mock/tm-1/architecture.png",
     "assets": {
-      "assets": [
-        { "id": "asset-1", "name": "Card details", "description": "PCI-sensitive data" }
-      ]
+      "assets": [{ "id": "asset-1", "name": "Card details", "description": "PCI-sensitive data" }]
     },
     "system_architecture": {
       "trust_boundaries": [{ "id": "tb-1", "name": "External" }],

--- a/e2e/tests/advanced/attack-tree.spec.ts
+++ b/e2e/tests/advanced/attack-tree.spec.ts
@@ -15,9 +15,7 @@ test("opens the attack tree drawer for a threat", async ({ authenticatedPage }) 
   ).toBeVisible();
 });
 
-test("renders the ReactFlow canvas with mocked nodes and edges", async ({
-  authenticatedPage,
-}) => {
+test("renders the ReactFlow canvas with mocked nodes and edges", async ({ authenticatedPage }) => {
   await authenticatedPage.goto("/tm-1");
   await expect(
     authenticatedPage.getByText("Card details exfiltration", { exact: false }).first()
@@ -36,9 +34,7 @@ test("renders the ReactFlow canvas with mocked nodes and edges", async ({
   await expect(authenticatedPage.getByTestId("node-leaf-1")).toBeVisible();
 
   // Node text content is projected through Cloudscape components.
-  await expect(
-    authenticatedPage.getByText("Exfiltrate card details").first()
-  ).toBeVisible();
+  await expect(authenticatedPage.getByText("Exfiltrate card details").first()).toBeVisible();
   await expect(authenticatedPage.getByText("SQL injection on API").first()).toBeVisible();
 
   // One edge is drawn.

--- a/e2e/tests/advanced/conflict.spec.ts
+++ b/e2e/tests/advanced/conflict.spec.ts
@@ -57,9 +57,7 @@ test("a 409 PUT opens the ConflictResolutionModal with server timestamp info", a
   // The visible ConflictResolutionModal opens with the diff summary.
   const conflictModal = authenticatedPage.getByTestId("conflict-modal");
   await expect(conflictModal).toBeVisible({ timeout: 10_000 });
-  await expect(
-    conflictModal.getByText(/The threat model has been modified/i)
-  ).toBeVisible();
+  await expect(conflictModal.getByText(/The threat model has been modified/i)).toBeVisible();
   await expect(conflictModal.getByText("someone-else")).toBeVisible();
 
   // The two resolution actions are exposed.

--- a/e2e/tests/catalog/pagination.spec.ts
+++ b/e2e/tests/catalog/pagination.spec.ts
@@ -18,30 +18,27 @@ test.use({
 
 test("Load More fetches the next page and appends rows", async ({ authenticatedPage }) => {
   const cursors: (string | null)[] = [];
-  await authenticatedPage.route(
-    /\/api\/threat-designer\/owned(\?.*)?$/,
-    async (route) => {
-      const url = new URL(route.request().url());
-      const cursor = url.searchParams.get("cursor");
-      cursors.push(cursor);
-      if (cursor === "cursor-2") {
-        return route.fulfill({
-          json: {
-            catalogs: Array.from({ length: 5 }, (_, i) => ({
-              job_id: `tm-page2-${i + 1}`,
-              title: `Model page-2 #${i + 1}`,
-              summary: "Page 2 model",
-              timestamp: "2026-06-15T10:00:00Z",
-              is_owner: true,
-              stats: { high: 0, medium: 1, low: 0 },
-            })),
-            pagination: { cursor: null, hasNextPage: false },
-          },
-        });
-      }
-      return route.fallback();
+  await authenticatedPage.route(/\/api\/threat-designer\/owned(\?.*)?$/, async (route) => {
+    const url = new URL(route.request().url());
+    const cursor = url.searchParams.get("cursor");
+    cursors.push(cursor);
+    if (cursor === "cursor-2") {
+      return route.fulfill({
+        json: {
+          catalogs: Array.from({ length: 5 }, (_, i) => ({
+            job_id: `tm-page2-${i + 1}`,
+            title: `Model page-2 #${i + 1}`,
+            summary: "Page 2 model",
+            timestamp: "2026-06-15T10:00:00Z",
+            is_owner: true,
+            stats: { high: 0, medium: 1, low: 0 },
+          })),
+          pagination: { cursor: null, hasNextPage: false },
+        },
+      });
     }
-  );
+    return route.fallback();
+  });
 
   await authenticatedPage.goto("/threat-catalog");
   await expect(authenticatedPage.getByTestId("tm-card-tm-page1-1")).toBeVisible();

--- a/e2e/tests/sharing/access-levels.spec.ts
+++ b/e2e/tests/sharing/access-levels.spec.ts
@@ -7,9 +7,7 @@ test.use({
   },
 });
 
-test("non-owner sees no Share/Delete/Create-new-version actions", async ({
-  authenticatedPage,
-}) => {
+test("non-owner sees no Share/Delete/Create-new-version actions", async ({ authenticatedPage }) => {
   await authenticatedPage.goto("/tm-1");
   await expect(authenticatedPage.getByTestId("threat-model-header")).toBeVisible();
 
@@ -18,9 +16,9 @@ test("non-owner sees no Share/Delete/Create-new-version actions", async ({
   // Owner-only actions must NOT be present in the menu.
   await expect(authenticatedPage.getByRole("menuitem", { name: "Share" })).toHaveCount(0);
   await expect(authenticatedPage.getByRole("menuitem", { name: "Delete" })).toHaveCount(0);
-  await expect(
-    authenticatedPage.getByRole("menuitem", { name: "Create new version" })
-  ).toHaveCount(0);
+  await expect(authenticatedPage.getByRole("menuitem", { name: "Create new version" })).toHaveCount(
+    0
+  );
 
   // Non-mutating actions are still available.
   await expect(authenticatedPage.getByRole("menuitem", { name: "Trail" })).toBeVisible();

--- a/e2e/tests/sharing/share-modal.spec.ts
+++ b/e2e/tests/sharing/share-modal.spec.ts
@@ -16,16 +16,13 @@ test("opens the sharing modal and lists existing collaborators", async ({ authen
 
 test("adds a new collaborator and fires a POST /share", async ({ authenticatedPage }) => {
   let sharePost: Record<string, unknown> | null = null;
-  await authenticatedPage.route(
-    /\/threat-designer\/tm-1\/share(\?.*)?$/,
-    async (route) => {
-      if (route.request().method() === "POST") {
-        sharePost = route.request().postDataJSON();
-        return route.fulfill({ json: { ok: true } });
-      }
-      return route.fallback();
+  await authenticatedPage.route(/\/threat-designer\/tm-1\/share(\?.*)?$/, async (route) => {
+    if (route.request().method() === "POST") {
+      sharePost = route.request().postDataJSON();
+      return route.fulfill({ json: { ok: true } });
     }
-  );
+    return route.fallback();
+  });
 
   await authenticatedPage.goto("/tm-1");
   await authenticatedPage.getByRole("button", { name: "Actions" }).click();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,8 @@ export default [
         clearTimeout: "readonly",
         setInterval: "readonly",
         clearInterval: "readonly",
+        requestAnimationFrame: "readonly",
+        cancelAnimationFrame: "readonly",
         fetch: "readonly",
         Event: "readonly",
         CustomEvent: "readonly",

--- a/infra/authorizer.tf
+++ b/infra/authorizer.tf
@@ -91,7 +91,7 @@ resource "aws_lambda_provisioned_concurrency_config" "authorizer_lambda_alias_pr
   function_name                     = aws_lambda_alias.authorizer_lambda_alias.function_name
   provisioned_concurrent_executions = var.provisioned_lambda_concurrency
   qualifier                         = aws_lambda_alias.authorizer_lambda_alias.name
-  depends_on = [null_resource.wait_for_alias_stabilization]
+  depends_on                        = [null_resource.wait_for_alias_stabilization]
 
 }
 

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -127,6 +127,6 @@ resource "aws_lambda_provisioned_concurrency_config" "backend" {
   function_name                     = aws_lambda_alias.backend.function_name
   provisioned_concurrent_executions = var.provisioned_lambda_concurrency
   qualifier                         = aws_lambda_alias.backend.name
-  
+
   depends_on = [null_resource.wait_for_backend_alias_stabilization]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -29,6 +29,14 @@ provider "aws" {
   region = "us-east-1"
 }
 
+# The AgentCore web search connector is offered only in us-east-1, eu-west-1 and
+# ap-northeast-1, so its gateway may need to live outside var.region.
+# See infra/web_search.tf.
+provider "aws" {
+  alias  = "web_search"
+  region = var.web_search_region
+}
+
 # terraform {
 #   backend "s3" {}
 # }

--- a/infra/sentry.tf
+++ b/infra/sentry.tf
@@ -4,11 +4,11 @@ resource "aws_bedrockagentcore_agent_runtime" "sentry" {
   role_arn           = aws_iam_role.sentry_role[0].arn
   environment_variables = merge(
     {
-      SESSION_TABLE      = aws_dynamodb_table.sentry_session[0].id,
-      ATTACK_TREE_TABLE  = aws_dynamodb_table.attack_tree_data.id,
-      S3_BUCKET          = aws_s3_bucket.architecture_bucket.id,
-      REGION             = var.region,
-      MODEL_PROVIDER     = var.model_provider
+      SESSION_TABLE     = aws_dynamodb_table.sentry_session[0].id,
+      ATTACK_TREE_TABLE = aws_dynamodb_table.attack_tree_data.id,
+      S3_BUCKET         = aws_s3_bucket.architecture_bucket.id,
+      REGION            = var.region,
+      MODEL_PROVIDER    = var.model_provider
     },
     var.model_provider == "bedrock" ? {
       MODEL_ID                 = var.model_sentry.id,
@@ -18,13 +18,32 @@ resource "aws_bedrockagentcore_agent_runtime" "sentry" {
       EFFORT_MAP               = jsonencode(var.model_sentry.effort_map)
     } : {},
     var.model_provider == "openai" ? {
-      OPENAI_API_KEY    = var.openai_api_key,
-      MODEL_ID          = var.openai_model_sentry.id,
-      MAX_TOKENS        = tostring(var.openai_model_sentry.max_tokens),
-      REASONING_EFFORT  = jsonencode(var.openai_model_sentry.reasoning_effort)
+      OPENAI_API_KEY   = var.openai_api_key,
+      MODEL_ID         = var.openai_model_sentry.id,
+      MAX_TOKENS       = tostring(var.openai_model_sentry.max_tokens),
+      REASONING_EFFORT = jsonencode(var.openai_model_sentry.reasoning_effort)
     } : {},
-    var.tavily_api_key != "" ? {
+    # Same GPT model as "openai", served via the Bedrock Mantle endpoint —
+    # SigV4 bearer-token auth from the runtime role, no OpenAI API key.
+    var.model_provider == "bedrock-mantle" ? {
+      MODEL_ID         = var.openai_model_sentry.id,
+      MAX_TOKENS       = tostring(var.openai_model_sentry.max_tokens),
+      REASONING_EFFORT = jsonencode(var.openai_model_sentry.reasoning_effort),
+      MANTLE_REGION    = var.mantle_region
+    } : {},
+    {
+      WEB_SEARCH_PROVIDER = var.web_search_provider
+    },
+    var.web_search_provider == "tavily" ? {
       TAVILY_API_KEY = var.tavily_api_key
+    } : {},
+    # The gateway URL is what actually enables the tool at runtime; without it
+    # web_search_tools.py logs and returns no tool rather than 403-ing.
+    local.web_search_agentcore ? {
+      WEB_SEARCH_GATEWAY_URL = aws_bedrockagentcore_gateway.web_search[0].gateway_url,
+      WEB_SEARCH_REGION      = var.web_search_region,
+      WEB_SEARCH_TOOL_NAME   = local.web_search_tool_name,
+      WEB_SEARCH_MAX_RESULTS = tostring(var.web_search_max_results)
     } : {}
   )
   authorizer_configuration {
@@ -46,9 +65,33 @@ resource "aws_bedrockagentcore_agent_runtime" "sentry" {
   }
   lifecycle_configuration {
     idle_runtime_session_timeout = 3600
-    max_lifetime = 28800
+    max_lifetime                 = 28800
   }
-  depends_on = [null_resource.docker_build_push]
+
+  # Web search is configured by env var, so a misconfiguration costs Sentry the
+  # tool with no error anywhere. Fail the apply instead of shipping a silently
+  # search-less assistant. A leftover key alongside "agentcore" is deliberate and
+  # allowed; only "I set the key but never selected the provider" is caught.
+  lifecycle {
+    precondition {
+      condition     = !(var.web_search_provider == "none" && var.tavily_api_key != "")
+      error_message = "tavily_api_key is set but web_search_provider is \"none\" — set web_search_provider = \"tavily\" to enable it, or clear the key."
+    }
+    precondition {
+      condition     = !(var.web_search_provider == "tavily" && var.tavily_api_key == "")
+      error_message = "web_search_provider is \"tavily\" but tavily_api_key is empty — Sentry would start with no web search."
+    }
+  }
+
+  # The runtime reads WEB_SEARCH_GATEWAY_URL at startup and signs its own calls,
+  # so both the gateway target and this role's invoke permission have to exist
+  # first. Without these, an early tools/call gets a 403 or "no such tool" and
+  # the model only sees the wrapped "Error: web_search failed" string.
+  depends_on = [
+    null_resource.docker_build_push,
+    aws_cloudcontrolapi_resource.web_search_target,
+    aws_iam_role_policy.sentry_web_search_policy,
+  ]
 }
 
 
@@ -118,6 +161,65 @@ resource "aws_iam_role" "sentry_role" {
             "aws:SourceArn" : "arn:aws:bedrock-agentcore:${var.region}:${data.aws_caller_identity.caller_identity.account_id}:*"
           }
         }
+      }
+    ]
+  })
+}
+
+# Bedrock Mantle (OpenAI-compatible endpoint) — separate IAM namespace from
+# bedrock:*. Same grant shape as the threat designer agent's mantle policy;
+# see the comment there. Present only when Sentry is enabled AND the deploy
+# uses the bedrock-mantle provider.
+resource "aws_iam_role_policy" "sentry_mantle_policy" {
+  count = var.enable_sentry && var.model_provider == "bedrock-mantle" ? 1 : 0
+  name  = "${local.prefix}-sentry-mantle-policy"
+  role  = aws_iam_role.sentry_role[0].id
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "BedrockMantleInvoke",
+        "Effect" : "Allow",
+        "Action" : [
+          "bedrock-mantle:CreateInference",
+          "bedrock-mantle:GetInference",
+          "bedrock-mantle:GetModel",
+          "bedrock-mantle:ListModels"
+        ],
+        "Resource" : [
+          "arn:aws:bedrock-mantle:${var.mantle_region}:${data.aws_caller_identity.caller_identity.account_id}:project/default"
+        ]
+      },
+      {
+        "Sid" : "BedrockMantleBearerToken",
+        "Effect" : "Allow",
+        "Action" : ["bedrock-mantle:CallWithBearerToken"],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+# The Sentry runtime calls the web search gateway directly, signing with SigV4
+# from this role (the gateway's inbound authorizer is AWS_IAM). Scoped to the one
+# gateway we provision, and absent unless the agentcore provider is selected.
+resource "aws_iam_role_policy" "sentry_web_search_policy" {
+  count = local.web_search_agentcore ? 1 : 0
+  name  = "${local.prefix}-sentry-web-search-policy"
+  role  = aws_iam_role.sentry_role[0].id
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "WebSearchGateway",
+        "Effect" : "Allow",
+        "Action" : ["bedrock-agentcore:InvokeGateway"],
+        "Resource" : [
+          "arn:aws:bedrock-agentcore:${var.web_search_region}:${data.aws_caller_identity.caller_identity.account_id}:gateway/${aws_bedrockagentcore_gateway.web_search[0].gateway_id}",
+          "arn:aws:bedrock-agentcore:${var.web_search_region}:${data.aws_caller_identity.caller_identity.account_id}:gateway/${aws_bedrockagentcore_gateway.web_search[0].gateway_id}/*"
+        ]
       }
     ]
   })

--- a/infra/spaces.tf
+++ b/infra/spaces.tf
@@ -255,8 +255,8 @@ resource "aws_iam_role_policy" "backend_spaces_policy" {
         Resource = [aws_s3_bucket.spaces_bucket.arn, "${aws_s3_bucket.spaces_bucket.arn}/*"]
       },
       {
-        Effect   = "Allow"
-        Action   = ["bedrock:StartIngestionJob", "bedrock-agent:StartIngestionJob", "bedrock:ListIngestionJobs", "bedrock-agent:ListIngestionJobs"]
+        Effect = "Allow"
+        Action = ["bedrock:StartIngestionJob", "bedrock-agent:StartIngestionJob", "bedrock:ListIngestionJobs", "bedrock-agent:ListIngestionJobs"]
         Resource = [
           aws_bedrockagent_knowledge_base.spaces_kb.arn,
           "${aws_bedrockagent_knowledge_base.spaces_kb.arn}/*",

--- a/infra/stream_processor.tf
+++ b/infra/stream_processor.tf
@@ -108,13 +108,13 @@ resource "aws_lambda_function" "stream_processor" {
 # --- Event Source Mapping: DynamoDB Stream → Lambda ---
 
 resource "aws_lambda_event_source_mapping" "stream_processor_trigger" {
-  event_source_arn                   = aws_dynamodb_table.threat_designer_state.stream_arn
-  function_name                      = aws_lambda_function.stream_processor.arn
-  starting_position                  = "LATEST"
-  batch_size                         = 1
-  maximum_retry_attempts             = 3
-  bisect_batch_on_function_error     = false
-  maximum_record_age_in_seconds      = -1
+  event_source_arn               = aws_dynamodb_table.threat_designer_state.stream_arn
+  function_name                  = aws_lambda_function.stream_processor.arn
+  starting_position              = "LATEST"
+  batch_size                     = 1
+  maximum_retry_attempts         = 3
+  bisect_batch_on_function_error = false
+  maximum_record_age_in_seconds  = -1
 
   destination_config {
     on_failure {

--- a/infra/threat_designer_agent_core.tf
+++ b/infra/threat_designer_agent_core.tf
@@ -22,10 +22,19 @@ resource "aws_bedrockagentcore_agent_runtime" "threat_designer" {
       ADAPTIVE_THINKING_MODELS = jsonencode(var.adaptive_thinking_models)
     } : {},
     var.model_provider == "openai" ? {
-      OPENAI_API_KEY   = var.openai_api_key,
-      MAIN_MODEL       = jsonencode(var.openai_model_main),
-      MODEL_STRUCT     = jsonencode(var.openai_model_struct),
-      MODEL_SUMMARY    = jsonencode(var.openai_model_summary),
+      OPENAI_API_KEY = var.openai_api_key,
+      MAIN_MODEL     = jsonencode(var.openai_model_main),
+      MODEL_STRUCT   = jsonencode(var.openai_model_struct),
+      MODEL_SUMMARY  = jsonencode(var.openai_model_summary),
+    } : {},
+    # Same GPT models as "openai", served via the Bedrock Mantle endpoint —
+    # SigV4 bearer-token auth from the runtime role, no OpenAI API key. The
+    # runtime prefixes the "openai." Mantle model-id form itself.
+    var.model_provider == "bedrock-mantle" ? {
+      MAIN_MODEL    = jsonencode(var.openai_model_main),
+      MODEL_STRUCT  = jsonencode(var.openai_model_struct),
+      MODEL_SUMMARY = jsonencode(var.openai_model_summary),
+      MANTLE_REGION = var.mantle_region
     } : {}
   )
   agent_runtime_artifact {
@@ -38,7 +47,7 @@ resource "aws_bedrockagentcore_agent_runtime" "threat_designer" {
   }
   lifecycle_configuration {
     idle_runtime_session_timeout = 7200
-    max_lifetime = 28800
+    max_lifetime                 = 28800
   }
   depends_on = [null_resource.docker_agent_build_push]
 }
@@ -133,6 +142,47 @@ resource "aws_iam_role_policy" "policy_agent" {
     status_table_arn      = aws_dynamodb_table.threat_designer_status.arn,
     attack_tree_table_arn = aws_dynamodb_table.attack_tree_data.arn,
     architecture_bucket   = aws_s3_bucket.architecture_bucket.arn
+  })
+}
+
+# Bedrock Mantle (OpenAI-compatible endpoint) — a SEPARATE IAM namespace from
+# bedrock:*; the bedrock:InvokeModel grant does NOT cover it. The bearer token
+# provide_token() mints inherits THIS role's identity, so the role itself needs
+# these actions: CreateInference at invoke time (missing -> 401
+# permission_denied), Get*/List* for model discovery. Scoped to the Mantle
+# "default" project in var.mantle_region (independent of var.region — GPT-5.x
+# on Mantle is US-regions only). CallWithBearerToken is the bearer-auth action
+# itself and is not project- or region-scopable, so it takes Resource "*".
+# Absent unless the deploy uses the bedrock-mantle provider, keeping the role
+# least-privilege otherwise.
+resource "aws_iam_role_policy" "threat_designer_mantle_policy" {
+  count = var.model_provider == "bedrock-mantle" ? 1 : 0
+  name  = "${local.prefix}-agent-mantle-policy"
+  role  = aws_iam_role.threat_designer_role.id
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "BedrockMantleInvoke",
+        "Effect" : "Allow",
+        "Action" : [
+          "bedrock-mantle:CreateInference",
+          "bedrock-mantle:GetInference",
+          "bedrock-mantle:GetModel",
+          "bedrock-mantle:ListModels"
+        ],
+        "Resource" : [
+          "arn:aws:bedrock-mantle:${var.mantle_region}:${data.aws_caller_identity.caller_identity.account_id}:project/default"
+        ]
+      },
+      {
+        "Sid" : "BedrockMantleBearerToken",
+        "Effect" : "Allow",
+        "Action" : ["bedrock-mantle:CallWithBearerToken"],
+        "Resource" : "*"
+      }
+    ]
   })
 }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -54,7 +54,7 @@ variable "provisioned_lambda_concurrency" {
 variable "adaptive_thinking_models" {
   type        = list(string)
   description = "List of model IDs that support adaptive thinking"
-  default     = ["global.anthropic.claude-opus-4-7", "global.anthropic.claude-opus-4-6-v1", "global.anthropic.claude-sonnet-4-6"]
+  default     = ["global.anthropic.claude-opus-5", "global.anthropic.claude-sonnet-5", "global.anthropic.claude-opus-4-7", "global.anthropic.claude-opus-4-6-v1", "global.anthropic.claude-sonnet-4-6"]
 }
 
 
@@ -105,7 +105,7 @@ variable "model_main" {
   })
   default = {
     assets = {
-      id         = "global.anthropic.claude-opus-4-7"
+      id         = "global.anthropic.claude-opus-5"
       max_tokens = 128000
       reasoning_budget = {
         "1" = 16000
@@ -121,7 +121,7 @@ variable "model_main" {
       }
     }
     flows = {
-      id         = "global.anthropic.claude-opus-4-7"
+      id         = "global.anthropic.claude-opus-5"
       max_tokens = 128000
       reasoning_budget = {
         "1" = 16000
@@ -137,7 +137,7 @@ variable "model_main" {
       }
     }
     threats = {
-      id         = "global.anthropic.claude-opus-4-7"
+      id         = "global.anthropic.claude-opus-5"
       max_tokens = 128000
       reasoning_budget = {
         "1" = 16000
@@ -153,7 +153,7 @@ variable "model_main" {
       }
     }
     threats_agent = {
-      id         = "global.anthropic.claude-opus-4-7"
+      id         = "global.anthropic.claude-opus-5"
       max_tokens = 128000
       reasoning_budget = {
         "1" = 16000
@@ -169,7 +169,7 @@ variable "model_main" {
       }
     }
     gaps = {
-      id         = "global.anthropic.claude-opus-4-7"
+      id         = "global.anthropic.claude-opus-5"
       max_tokens = 128000
       reasoning_budget = {
         "1" = 16000
@@ -185,7 +185,12 @@ variable "model_main" {
       }
     }
     attack_tree = {
-      id         = "global.anthropic.claude-opus-4-7"
+      # Sonnet 5, not Opus 5, on purpose. Opus 5 content-filters the attack-tree
+      # prompt (stopReason=content_filtered with an EMPTY body, 3/3 runs
+      # verified 2026-08-23) — enumerating concrete techniques for a target
+      # reads as dual-use to its safety layer, and it fails SILENTLY rather
+      # than erroring. Sonnet 5 completes the same prompt cleanly (3/3).
+      id         = "global.anthropic.claude-sonnet-5"
       max_tokens = 128000
       reasoning_budget = {
         "1" = 16000
@@ -201,7 +206,7 @@ variable "model_main" {
       }
     }
     version = {
-      id         = "global.anthropic.claude-opus-4-6-v1"
+      id         = "global.anthropic.claude-opus-5"
       max_tokens = 128000
       reasoning_budget = {
         "1" = 16000
@@ -213,7 +218,7 @@ variable "model_main" {
         "1" = "low"
         "2" = "medium"
         "3" = "high"
-        "4" = "max"
+        "4" = "xhigh"
       }
     }
   }
@@ -227,21 +232,21 @@ variable "model_sentry" {
     effort_map       = optional(map(string))
   })
   default = {
-      id         = "global.anthropic.claude-sonnet-4-6"
-      max_tokens = 128000
-      reasoning_budget = {
-        "1" = 16000
-        "2" = 24000
-        "3" = 38000
-        "4" = 63999
-      }
-      effort_map = {
-        "1" = "low"
-        "2" = "medium"
-        "3" = "high"
-        "4" = "max"
-      }
+    id         = "global.anthropic.claude-sonnet-5"
+    max_tokens = 128000
+    reasoning_budget = {
+      "1" = 16000
+      "2" = 24000
+      "3" = 38000
+      "4" = 63999
     }
+    effort_map = {
+      "1" = "low"
+      "2" = "medium"
+      "3" = "high"
+      "4" = "xhigh"
+    }
+  }
 }
 
 variable "model_struct" {
@@ -250,7 +255,7 @@ variable "model_struct" {
     max_tokens = number
   })
   default = {
-    id         =  "global.anthropic.claude-sonnet-4-6"
+    id         = "global.anthropic.claude-sonnet-5"
     max_tokens = 64000
   }
 }
@@ -300,12 +305,23 @@ variable "enable_maestro" {
 
 variable "model_provider" {
   type        = string
-  description = "Model provider to use: bedrock or openai"
+  description = "Model provider to use: bedrock (Claude via Converse), openai (GPT via the OpenAI API), or bedrock-mantle (GPT via the Bedrock Mantle OpenAI-compatible endpoint — no OpenAI API key, SigV4 bearer-token auth)"
   default     = "openai"
 
   validation {
-    condition     = contains(["bedrock", "openai"], var.model_provider)
-    error_message = "model_provider must be either 'bedrock' or 'openai'"
+    condition     = contains(["bedrock", "openai", "bedrock-mantle"], var.model_provider)
+    error_message = "model_provider must be 'bedrock', 'openai', or 'bedrock-mantle'"
+  }
+}
+
+variable "mantle_region" {
+  type        = string
+  description = "AWS region for the Bedrock Mantle endpoint when model_provider is bedrock-mantle. Independent of var.region — GPT-5.x on Mantle is only served from US regions."
+  default     = "us-east-2"
+
+  validation {
+    condition     = contains(["us-east-2", "us-west-2"], var.mantle_region)
+    error_message = "GPT-5.x on Bedrock Mantle is only available in us-east-2 and us-west-2"
   }
 }
 
@@ -357,10 +373,9 @@ variable "openai_model_main" {
   description = "OpenAI model configurations for main workflow stages"
   default = {
     assets = {
-      id         = "gpt-5.4-2026-03-05"
+      id         = "gpt-5.6-sol"
       max_tokens = 128000
       reasoning_effort = {
-        "0" = "none"
         "1" = "low"
         "2" = "medium"
         "3" = "high"
@@ -368,10 +383,9 @@ variable "openai_model_main" {
       }
     }
     flows = {
-      id         = "gpt-5.4-2026-03-05"
+      id         = "gpt-5.6-sol"
       max_tokens = 128000
       reasoning_effort = {
-        "0" = "none"
         "1" = "low"
         "2" = "medium"
         "3" = "high"
@@ -379,10 +393,9 @@ variable "openai_model_main" {
       }
     }
     threats = {
-      id         = "gpt-5.4-2026-03-05"
+      id         = "gpt-5.6-sol"
       max_tokens = 128000
       reasoning_effort = {
-        "0" = "none"
         "1" = "low"
         "2" = "medium"
         "3" = "high"
@@ -390,10 +403,9 @@ variable "openai_model_main" {
       }
     }
     threats_agent = {
-      id         = "gpt-5.4-2026-03-05"
+      id         = "gpt-5.6-sol"
       max_tokens = 128000
       reasoning_effort = {
-        "0" = "none"
         "1" = "low"
         "2" = "medium"
         "3" = "high"
@@ -401,10 +413,9 @@ variable "openai_model_main" {
       }
     }
     gaps = {
-      id         = "gpt-5.4-2026-03-05"
+      id         = "gpt-5.6-sol"
       max_tokens = 128000
       reasoning_effort = {
-        "0" = "none"
         "1" = "low"
         "2" = "medium"
         "3" = "high"
@@ -412,10 +423,13 @@ variable "openai_model_main" {
       }
     }
     attack_tree = {
-      id         = "gpt-5.4-2026-03-05"
+      # Terra, not Sol, on purpose — the counterpart of the Claude side using
+      # Sonnet 5 rather than Opus 5 for this stage. Enumerating concrete attack
+      # techniques for a target reads as dual-use to the provider safety layers,
+      # and the flagship models are the strictest about it.
+      id         = "gpt-5.6-terra"
       max_tokens = 128000
       reasoning_effort = {
-        "0" = "none"
         "1" = "low"
         "2" = "medium"
         "3" = "high"
@@ -423,10 +437,9 @@ variable "openai_model_main" {
       }
     }
     version = {
-      id         = "gpt-5.4-2026-03-05"
+      id         = "gpt-5.6-sol"
       max_tokens = 128000
       reasoning_effort = {
-        "0" = "none"
         "1" = "low"
         "2" = "medium"
         "3" = "high"
@@ -444,10 +457,9 @@ variable "openai_model_sentry" {
   })
   description = "OpenAI model configuration for Sentry assistant"
   default = {
-    id         = "gpt-5.4-2026-03-05"
+    id         = "gpt-5.6-terra"
     max_tokens = 128000
     reasoning_effort = {
-      "0" = "none"
       "1" = "low"
       "2" = "medium"
       "3" = "high"
@@ -463,7 +475,7 @@ variable "openai_model_struct" {
   })
   description = "OpenAI model configuration for structured output"
   default = {
-    id         = "gpt-5.4-2026-03-05"
+    id         = "gpt-5.6-terra"
     max_tokens = 64000
   }
 }
@@ -475,14 +487,47 @@ variable "openai_model_summary" {
   })
   description = "OpenAI model configuration for summary generation"
   default = {
-    id         = "gpt-5.4-2026-03-05"
+    id         = "gpt-5.6-luna"
     max_tokens = 4000
+  }
+}
+
+variable "web_search_provider" {
+  type        = string
+  description = "Web search provider for Sentry: none, tavily (search + page extraction, needs an API key), or agentcore (Bedrock AgentCore web search connector, no API key — search only, no page extraction)"
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "tavily", "agentcore"], var.web_search_provider)
+    error_message = "web_search_provider must be 'none', 'tavily', or 'agentcore'"
+  }
+}
+
+variable "web_search_region" {
+  type        = string
+  description = "AWS region hosting the AgentCore web search gateway. Independent of var.region — the connector is only offered in these three regions. Queries are served inside AWS but may leave the deployment's region."
+  default     = "us-east-1"
+
+  validation {
+    condition     = contains(["us-east-1", "eu-west-1", "ap-northeast-1"], var.web_search_region)
+    error_message = "The AgentCore web search connector is only available in us-east-1, eu-west-1 and ap-northeast-1"
+  }
+}
+
+variable "web_search_max_results" {
+  type        = number
+  description = "Default number of results the AgentCore web_search tool requests (1-25)"
+  default     = 5
+
+  validation {
+    condition     = var.web_search_max_results >= 1 && var.web_search_max_results <= 25
+    error_message = "web_search_max_results must be between 1 and 25"
   }
 }
 
 variable "tavily_api_key" {
   type        = string
-  description = "Tavily API key for web search and content extraction (optional)"
+  description = "Tavily API key for web search and content extraction (used when web_search_provider is 'tavily')"
   default     = ""
   sensitive   = true
 }

--- a/infra/web_search.tf
+++ b/infra/web_search.tf
@@ -1,0 +1,146 @@
+# AgentCore web search for Sentry (var.web_search_provider == "agentcore").
+#
+# Web Search on Bedrock AgentCore is only reachable as a built-in CONNECTOR
+# TARGET on an AgentCore Gateway, which speaks MCP — there is no direct
+# data-plane search API. So this file provisions:
+#
+#   1. a gateway service role (what the gateway itself uses to reach the
+#      connector: bedrock-agentcore:InvokeWebSearch on the service-owned ARN);
+#   2. an MCP gateway with AWS_IAM inbound auth, so the Sentry runtime
+#      authenticates with SigV4 from its own execution role — no JWT, no client
+#      secret to vend;
+#   3. the web-search connector target.
+#
+# Two non-obvious constraints are baked in here:
+#
+# * REGION — the connector is offered in us-east-1, eu-west-1 and
+#   ap-northeast-1 only, so every resource here uses the aws.web_search
+#   provider alias (var.web_search_region) rather than var.region. A query still
+#   never leaves AWS (the gateway serves it internally) but it can leave the
+#   deployment's region; that trade-off is why the provider is opt-in.
+#
+# * The target is an aws_cloudcontrolapi_resource, NOT
+#   aws_bedrockagentcore_gateway_target. In hashicorp/aws 6.52 that resource's
+#   target_configuration.mcp block supports lambda / api_gateway / mcp_server /
+#   open_api_schema / smithy_model — but NOT `connector`, which is the shape web
+#   search needs (verified against `terraform providers schema`).
+#   AWS::BedrockAgentCore::GatewayTarget in the CloudFormation registry does
+#   support Connector, so Cloud Control gives the same declarative
+#   create/update/destroy through the same provider. Swap this for the native
+#   resource once it grows a `connector` block.
+#
+# Deliberately NOT pinned to connector 1.2.0: the request-level date/domain
+# filters that version adds cannot be pinned declaratively (the registry's
+# ConnectorSource carries only ConnectorId) and a pre-1.2.0 target silently
+# IGNORES an unknown `filters` argument instead of rejecting it. The runtime
+# therefore stays on the base query + maxResults surface — see
+# backend/sentry/web_search_tools.py.
+
+locals {
+  web_search_agentcore = var.web_search_provider == "agentcore" && var.enable_sentry
+
+  # The gateway-side tool name is `<target_name>___<tool>` (three underscores) —
+  # AgentCore prefixes every tool with its target's name to keep names unique
+  # across targets. The runtime can discover this via tools/list, but passing it
+  # explicitly saves a round trip on the first search of each process.
+  web_search_target_name = "${local.prefix}-web-search"
+  web_search_tool_name   = "${local.prefix}-web-search___WebSearch"
+}
+
+# --- the gateway's own service role -------------------------------------------
+
+data "aws_iam_policy_document" "web_search_gateway_assume" {
+  count = local.web_search_agentcore ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "web_search_gateway" {
+  count = local.web_search_agentcore ? 1 : 0
+
+  # The gateway invokes itself on the caller's behalf...
+  statement {
+    sid       = "InvokeGateway"
+    actions   = ["bedrock-agentcore:InvokeGateway"]
+    resources = ["arn:aws:bedrock-agentcore:${var.web_search_region}:${data.aws_caller_identity.caller_identity.account_id}:gateway/*"]
+  }
+
+  # ...and this authorizes the search itself. The resource is a SERVICE-OWNED
+  # ARN (the account field is literally "aws"), checked per request.
+  statement {
+    sid       = "InvokeWebSearch"
+    actions   = ["bedrock-agentcore:InvokeWebSearch"]
+    resources = ["arn:aws:bedrock-agentcore:${var.web_search_region}:aws:tool/web-search.v1"]
+  }
+}
+
+resource "aws_iam_role" "web_search_gateway" {
+  count = local.web_search_agentcore ? 1 : 0
+
+  name               = "${local.prefix}-web-search-gateway"
+  assume_role_policy = data.aws_iam_policy_document.web_search_gateway_assume[0].json
+}
+
+resource "aws_iam_role_policy" "web_search_gateway" {
+  count = local.web_search_agentcore ? 1 : 0
+
+  name   = "${local.prefix}-web-search-gateway-policy"
+  role   = aws_iam_role.web_search_gateway[0].id
+  policy = data.aws_iam_policy_document.web_search_gateway[0].json
+}
+
+# --- the gateway --------------------------------------------------------------
+
+# AWS_IAM inbound auth: the only caller is the Sentry runtime, which signs with
+# SigV4 from its execution role (see the WebSearchGateway statement in
+# sentry.tf). CUSTOM_JWT would mean vending and rotating a Cognito M2M client
+# for a purely server-to-server hop — IAM is both simpler and tighter.
+resource "aws_bedrockagentcore_gateway" "web_search" {
+  count    = local.web_search_agentcore ? 1 : 0
+  provider = aws.web_search
+
+  name            = "${local.prefix}-web-search"
+  description     = "Web search connector for the Sentry assistant"
+  role_arn        = aws_iam_role.web_search_gateway[0].arn
+  protocol_type   = "MCP"
+  authorizer_type = "AWS_IAM"
+
+  # Same IAM-propagation race as the runtimes: CreateGateway validates the
+  # service role, which can be a stale snapshot seconds after PutRolePolicy.
+  depends_on = [aws_iam_role_policy.web_search_gateway]
+}
+
+# --- the web-search connector target ------------------------------------------
+
+resource "aws_cloudcontrolapi_resource" "web_search_target" {
+  count    = local.web_search_agentcore ? 1 : 0
+  provider = aws.web_search
+
+  type_name = "AWS::BedrockAgentCore::GatewayTarget"
+
+  desired_state = jsonencode({
+    Name              = local.web_search_target_name
+    GatewayIdentifier = aws_bedrockagentcore_gateway.web_search[0].gateway_id
+    Description       = "Amazon-operated web index, MCP tool WebSearch"
+    TargetConfiguration = {
+      Mcp = {
+        Connector = {
+          Source         = { ConnectorId = "web-search" }
+          Configurations = [{ Name = "WebSearch", ParameterValues = {} }]
+        }
+      }
+    }
+    # Connector targets need no iamCredentialProvider — the connector's service
+    # name is already known to the gateway, so the role alone is the config.
+    CredentialProviderConfigurations = [
+      { CredentialProviderType = "GATEWAY_IAM_ROLE" }
+    ]
+  })
+}

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -14,7 +14,11 @@ license = {text = "APACHE"}
 requires-python = ">=3.10"
 dependencies = [
     "boto3",
-    "mcp>=1.0.0",
+    # Cap below 2.0: mcp 2.0.0 removed the bundled mcp.server.fastmcp package
+    # that server.py imports Context and FastMCP from, so an unbounded
+    # requirement resolves to 2.x and the server dies at import. Same reason as
+    # the pin in backend/sentry/requirements.txt, different relocated module.
+    "mcp>=1.9.2,<2.0.0",
     "fastmcp",
     "httpx>=0.24.0",
     "pydantic>=2.0.0",

--- a/mcp-server/threat_designer_mcp/state.py
+++ b/mcp-server/threat_designer_mcp/state.py
@@ -13,9 +13,9 @@ class StartThreatModeling(BaseModel):
     )
     reasoning: int = Field(
         default=2,
-        description="The level of reasoning  the agent should use for the threat analysis: 0=none, 1=low, 2=medium, 3=high effort",
-        ge=0,
-        le=3,
+        description="The level of reasoning the agent should use for the threat analysis: 1=low, 2=medium, 3=high, 4=extra high effort",
+        ge=1,
+        le=4,
     )
     iteration: int = Field(
         default=0,

--- a/mcp-server/threat_designer_mcp/utils.py
+++ b/mcp-server/threat_designer_mcp/utils.py
@@ -1,8 +1,15 @@
-import imghdr
 import os
 from typing import Any, Dict, List
 
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
+
+# Pillow format names for the two formats the upload endpoint accepts, mapped to
+# the lowercase subtype the caller drops straight into an "image/..." MIME type.
+# This replaces imghdr, which was deprecated in Python 3.11 and REMOVED in 3.13 —
+# and since requires-python allows 3.13+, importing it broke the whole package on
+# a current interpreter. Pillow already opens this file for its dimensions, so
+# sniffing the format here costs nothing extra.
+_SUPPORTED_FORMATS = {"PNG": "png", "JPEG": "jpeg"}
 
 
 def validate_image(file_path):
@@ -32,20 +39,27 @@ def validate_image(file_path):
             f"File size ({size_mb:.2f} MB) exceeds maximum allowed size (3.75 MB)"
         )
 
-    # Check file type
-    img_type = imghdr.what(file_path)
-    if img_type not in ["png", "jpeg"]:
+    # Check file type and dimensions from the same header read
+    try:
+        with Image.open(file_path) as img:
+            img_format = img.format
+            width, height = img.size
+    except UnidentifiedImageError as exc:
         raise ValueError(
-            f"Unsupported image format: {img_type}. Only PNG and JPEG are supported"
+            "Unsupported image format: file is not a recognized image. "
+            "Only PNG and JPEG are supported"
+        ) from exc
+
+    img_type = _SUPPORTED_FORMATS.get(img_format)
+    if img_type is None:
+        raise ValueError(
+            f"Unsupported image format: {img_format}. Only PNG and JPEG are supported"
         )
 
-    # Check image dimensions
-    with Image.open(file_path) as img:
-        width, height = img.size
-        if width > 8000 or height > 8000:
-            raise ValueError(
-                f"Image dimensions ({width}x{height}) exceed maximum allowed dimensions (8000x8000)"
-            )
+    if width > 8000 or height > 8000:
+        raise ValueError(
+            f"Image dimensions ({width}x{height}) exceed maximum allowed dimensions (8000x8000)"
+        )
 
     return img_type, width, height
 

--- a/quick-start-guide/export-threat-models.md
+++ b/quick-start-guide/export-threat-models.md
@@ -17,13 +17,13 @@ Export your threat model when you need to:
 
 ## Export Formats Comparison
 
-| Format | Best For | Pros | Cons |
-|--------|----------|------|------|
-| **PDF** | Stakeholder presentations, executive reports, compliance documentation | Professional appearance, universally readable, preserves formatting | Not editable, larger file size |
-| **DOCX** | Technical documentation, collaborative editing, customization | Editable in Word, flexible formatting, easy to modify | Requires Microsoft Word or compatible editor |
-| **Excel (.xlsx)** | Data analysis, filtering, pivot tables, spreadsheet workflows | Sortable/filterable, multi-sheet structure, familiar to analysts | Requires Excel or compatible editor |
-| **Markdown (.md)** | AI/LLM integration, developer documentation, version control | AI-readable, lightweight, Git-friendly, human-readable | No rich formatting, no embedded images |
-| **JSON** | Automation, integration, data analysis, custom tooling | Machine-readable, complete data structure, scriptable | Not human-friendly, requires technical knowledge |
+| Format             | Best For                                                               | Pros                                                                | Cons                                             |
+| ------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------ |
+| **PDF**            | Stakeholder presentations, executive reports, compliance documentation | Professional appearance, universally readable, preserves formatting | Not editable, larger file size                   |
+| **DOCX**           | Technical documentation, collaborative editing, customization          | Editable in Word, flexible formatting, easy to modify               | Requires Microsoft Word or compatible editor     |
+| **Excel (.xlsx)**  | Data analysis, filtering, pivot tables, spreadsheet workflows          | Sortable/filterable, multi-sheet structure, familiar to analysts    | Requires Excel or compatible editor              |
+| **Markdown (.md)** | AI/LLM integration, developer documentation, version control           | AI-readable, lightweight, Git-friendly, human-readable              | No rich formatting, no embedded images           |
+| **JSON**           | Automation, integration, data analysis, custom tooling                 | Machine-readable, complete data structure, scriptable               | Not human-friendly, requires technical knowledge |
 
 ---
 
@@ -51,6 +51,7 @@ Click your desired format. The file will be generated client-side and downloaded
 ### PDF Export
 
 Generates a professional report with:
+
 - Title, description, and metadata
 - Architecture diagram (embedded image)
 - Assumptions list
@@ -62,6 +63,7 @@ Generates a professional report with:
 ### DOCX Export
 
 Generates an editable Word document with the same structure as PDF:
+
 - All sections from your threat model
 - Formatted tables for threats
 - Editable content for further customization
@@ -72,20 +74,21 @@ Generates an editable Word document with the same structure as PDF:
 
 Generates a multi-sheet workbook:
 
-| Sheet | Contents |
-|-------|----------|
-| **Summary** | Title, description, creation date, reasoning level |
-| **Threats** | Full threat catalog with ID, name, STRIDE category, description, risk score, likelihood, impact, mitigations, ISO controls, affected assets, status, comments |
-| **Assets** | Name, type, description, sensitivity |
-| **Data Flows** | Source, target, description |
-| **Trust Boundaries** | Source, target, purpose |
-| **Assumptions** | Listed assumptions |
+| Sheet                | Contents                                                                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Summary**          | Title, description, creation date, reasoning level                                                                                                            |
+| **Threats**          | Full threat catalog with ID, name, STRIDE category, description, risk score, likelihood, impact, mitigations, ISO controls, affected assets, status, comments |
+| **Assets**           | Name, type, description, sensitivity                                                                                                                          |
+| **Data Flows**       | Source, target, description                                                                                                                                   |
+| **Trust Boundaries** | Source, target, purpose                                                                                                                                       |
+| **Assumptions**      | Listed assumptions                                                                                                                                            |
 
 **Best for:** Data analysis, sorting/filtering threats, pivot tables, tracking remediation status.
 
 ### Markdown (.md) Export
 
 Generates a structured text document:
+
 - Title, description, and metadata
 - Assumptions as numbered list
 - Assets, data flows, trust boundaries as Markdown tables
@@ -100,6 +103,7 @@ Generates a structured text document:
 ### JSON Export
 
 Exports the complete threat model data structure including:
+
 - All metadata and settings
 - Architecture diagram (base64 encoded)
 - Assets, flows, boundaries, threat sources
@@ -112,31 +116,37 @@ Exports the complete threat model data structure including:
 ## Export Strategies by Audience
 
 ### Executive Summary
+
 - **Format:** PDF
 - **Focus:** High-level risk overview
 - **Tip:** Share only critical and high-risk threats
 
 ### Technical Deep-Dive
+
 - **Format:** DOCX or PDF
 - **Focus:** Complete analysis with all details
 - **Tip:** Include all sections for security engineers
 
 ### Compliance Audit
+
 - **Format:** PDF
 - **Focus:** Risk assessment with ISO27001 control mapping
 - **Tip:** Highlight risk scores and mitigation strategies
 
 ### Data Analysis
+
 - **Format:** Excel (.xlsx)
 - **Focus:** Sorting, filtering, pivot tables
 - **Tip:** Use the Threats sheet to create risk distribution charts
 
 ### AI/LLM Analysis
+
 - **Format:** Markdown (.md)
 - **Focus:** Feed into ChatGPT, Claude, or other AI tools
 - **Tip:** The structured format fits well in AI context windows
 
 ### Integration/Automation
+
 - **Format:** JSON
 - **Focus:** Programmatic access for custom tools
 - **Tip:** Parse the `threat_list.threats` array for threat data

--- a/src/components/Agent/AgentInterface.jsx
+++ b/src/components/Agent/AgentInterface.jsx
@@ -27,9 +27,8 @@ function ChatInterface({ user, inTools }) {
 
   // Use consolidated agent state hook
   const {
-    state: { budget, thinkingEnabled, toolItems, toolsInitialized, isFirstMountComplete },
+    state: { budget, toolItems, toolsInitialized, isFirstMountComplete },
     setBudget,
-    setThinkingEnabled,
     setToolItems,
     setFirstMountComplete,
   } = useAgentState();
@@ -115,19 +114,6 @@ function ChatInterface({ user, inTools }) {
     [setBudget]
   );
 
-  // Handle thinking toggle
-  const handleThinkingToggle = useCallback(
-    (isToggled) => {
-      setThinkingEnabled(isToggled);
-
-      if (isToggled && budget === "0") {
-        const defaultBudget = "1";
-        setBudget(defaultBudget);
-      }
-    },
-    [budget, setThinkingEnabled, setBudget]
-  );
-
   // Handle tool items change and save to localStorage
   const handleToolItemsChange = useCallback(
     (newItems) => {
@@ -157,23 +143,6 @@ function ChatInterface({ user, inTools }) {
     functions.dismissError(sessionId);
   }, [functions, sessionId]);
 
-  // Handle action button clicks
-  const handleActionButtonClick = useCallback(
-    (actionId, message, sessionId, isToggled) => {
-      switch (actionId) {
-        case "thinking":
-          handleThinkingToggle(isToggled);
-          break;
-        case "tools":
-          functions.sendMessage(sessionId, `Use tools to help with: ${message}`);
-          break;
-        default:
-          functions.sendMessage(sessionId, message);
-      }
-    },
-    [functions, handleThinkingToggle]
-  );
-
   // Memoize actionButtons to prevent recreation on every render
   const actionButtons = useMemo(
     () => [
@@ -181,18 +150,14 @@ function ChatInterface({ user, inTools }) {
         id: "think",
         label: "Think",
         icon: <ClockFading size={18} />,
-        // For OpenAI, make it non-toggleable (always active)
-        isToggle: true, //!isOpenAI,
+        // Thinking is always on — every current model is a reasoning model, so
+        // there is no off state. The dropdown still selects the effort level.
+        isToggle: false,
         showDropdown: true,
         dropdownContent: () => (
           <ThinkingBudgetWrapper initialBudget={budget} onBudgetChange={handleBudgetChange} />
         ),
-        defaultToggled: thinkingEnabled,
-        // For OpenAI, make it always appear active
-        alwaysActive: false, //isOpenAI,
-        onClick: (message, sessionId, isToggled) => {
-          handleActionButtonClick("thinking", message, sessionId, isToggled);
-        },
+        alwaysActive: true,
       },
       {
         id: "tools",
@@ -205,24 +170,7 @@ function ChatInterface({ user, inTools }) {
         ),
       },
     ],
-    [
-      budget,
-      thinkingEnabled,
-      handleBudgetChange,
-      handleActionButtonClick,
-      toolItems,
-      handleToolItemsChange,
-    ]
-  );
-
-  // Handle toggle button callbacks
-  const handleToggleButton = useCallback(
-    (buttonId, isToggled) => {
-      if (buttonId === "thinking") {
-        handleThinkingToggle(isToggled);
-      }
-    },
-    [handleThinkingToggle]
+    [budget, handleBudgetChange, toolItems, handleToolItemsChange]
   );
 
   const handleDropdownClick = useCallback(() => {
@@ -288,9 +236,8 @@ function ChatInterface({ user, inTools }) {
             autoFocus={true}
             isStreaming={isStreaming}
             tools={toolItems}
-            thinkingBudget={thinkingEnabled && budget}
+            thinkingBudget={budget}
             sessionId={sessionId}
-            onToggleButton={handleToggleButton}
             onDropdownClick={handleDropdownClick}
             onHeightChange={checkScrollPosition}
           />

--- a/src/components/Agent/ChatContent.jsx
+++ b/src/components/Agent/ChatContent.jsx
@@ -1,5 +1,10 @@
 import ChatTurn from "./ChatTurn";
 import React, { memo, useMemo } from "react";
+import { WEB_SEARCH_TOOLS, WEB_EXTRACT_TOOLS } from "./utils/constants";
+
+// Any tool whose result carries a `results[]` array of sources worth citing —
+// both web search providers and the extract tool.
+const WEB_RESULT_TOOLS = [...WEB_SEARCH_TOOLS, ...WEB_EXTRACT_TOOLS];
 
 /**
  * Extract web search results from message blocks for citation resolution
@@ -13,7 +18,7 @@ const extractWebSearchResults = (chatTurns) => {
     blocks.forEach((block) => {
       if (
         block.type === "tool" &&
-        (block.toolName === "tavily_search" || block.toolName === "tavily_extract") &&
+        WEB_RESULT_TOOLS.includes(block.toolName) &&
         block.content &&
         block.isComplete
       ) {

--- a/src/components/Agent/ChatContext.jsx
+++ b/src/components/Agent/ChatContext.jsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useRef, useEffect, useMemo 
 import { checkForInterruptInChatTurns } from "./context/utils";
 import { useChatSessionFunctions } from "./useChatSessionFunctions";
 import { SENTRY_ENABLED } from "./context/constants";
+import { drainAllSessions, cancelAllPumps } from "./context/sessionHelpers";
 
 // Split contexts
 export const ChatSessionFunctionsContext = createContext(null);
@@ -71,6 +72,16 @@ export const ChatSessionProvider = ({ children }) => {
     };
   }, [stableFunctions]);
 
+  // Hidden tabs get no animation frames, so the typewriter pump stalls while
+  // chunks keep queueing — and returning would replay the whole backlog at
+  // reveal rate, looking like live generation long after the run finished. The
+  // animation is a foreground nicety, so flush any backlog on a visibility flip.
+  useEffect(() => {
+    const onVisibilityChange = () => drainAllSessions(sessionRefs, setSessions);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -82,6 +93,8 @@ export const ChatSessionProvider = ({ children }) => {
           clearTimeout(refs.bufferTimeout);
         }
       });
+      // Drops any in-flight typewriter frame along with the session state.
+      cancelAllPumps(sessionRefs);
 
       sessionRefs.current.clear();
       initializedSessions.current.clear();

--- a/src/components/Agent/ChatInput.jsx
+++ b/src/components/Agent/ChatInput.jsx
@@ -20,7 +20,7 @@ const ChatInput = ({
   isStreaming = false,
   sessionId = null,
   tools = [],
-  thinkingBudget = 0,
+  thinkingBudget = 1,
   onToggleButton = () => {},
   onDropdownClick = () => {},
   onHeightChange = () => {},

--- a/src/components/Agent/CitationStyles.css
+++ b/src/components/Agent/CitationStyles.css
@@ -38,13 +38,13 @@
 
 /* Dark mode support */
 html.dark .web-citation-label,
-html.awsui-dark-mode .web-citation-label {
+.awsui-dark-mode .web-citation-label {
   background: rgba(96, 165, 250, 0.18);
   color: #60a5fa;
 }
 
 html.dark .web-citation-label:hover,
-html.awsui-dark-mode .web-citation-label:hover {
+.awsui-dark-mode .web-citation-label:hover {
   background: rgba(96, 165, 250, 0.28);
   color: #93c5fd;
 }
@@ -109,7 +109,7 @@ html.awsui-dark-mode .web-citation-label:hover {
 }
 
 html.dark .citation-popover,
-html.awsui-dark-mode .citation-popover {
+.awsui-dark-mode .citation-popover {
   border-color: rgba(255, 255, 255, 0.1);
 }
 
@@ -122,7 +122,7 @@ html.awsui-dark-mode .citation-popover {
 }
 
 html.dark .citation-popover-header,
-html.awsui-dark-mode .citation-popover-header {
+.awsui-dark-mode .citation-popover-header {
   color: #9ca3af;
   border-bottom-color: rgba(255, 255, 255, 0.08);
 }
@@ -150,12 +150,12 @@ html.awsui-dark-mode .citation-popover-header {
 }
 
 html.dark .citation-link-item,
-html.awsui-dark-mode .citation-link-item {
+.awsui-dark-mode .citation-link-item {
   color: #d1d5db;
 }
 
 html.dark .citation-link-item:hover,
-html.awsui-dark-mode .citation-link-item:hover {
+.awsui-dark-mode .citation-link-item:hover {
   background: rgba(255, 255, 255, 0.08);
 }
 
@@ -165,7 +165,7 @@ html.awsui-dark-mode .citation-link-item:hover {
 }
 
 html.dark .citation-link-icon,
-html.awsui-dark-mode .citation-link-icon {
+.awsui-dark-mode .citation-link-icon {
   color: #60a5fa;
 }
 
@@ -186,7 +186,7 @@ html.awsui-dark-mode .citation-link-icon {
 }
 
 html.dark .citation-external-icon,
-html.awsui-dark-mode .citation-external-icon {
+.awsui-dark-mode .citation-external-icon {
   color: #6b7280;
 }
 
@@ -215,6 +215,6 @@ html.awsui-dark-mode .citation-external-icon {
 
 /* Dark mode support for loading placeholder */
 html.dark .citation-loading,
-html.awsui-dark-mode .citation-loading {
+.awsui-dark-mode .citation-loading {
   background: rgba(96, 165, 250, 0.12);
 }

--- a/src/components/Agent/TextContent.jsx
+++ b/src/components/Agent/TextContent.jsx
@@ -313,6 +313,52 @@ const CITATION_PLACEHOLDER = '<span class="citation-loading"></span>';
 const CHART_PLACEHOLDER = '<span class="chart-loading-placeholder"></span>';
 
 /**
+ * Hide a tag that is still arriving, replacing it with a loading placeholder.
+ *
+ * Tags stream in one character at a time, so every intermediate prefix of
+ * `<chart config='{…}' />` and `<cite ref="1:1" />` gets rendered. Enumerating
+ * those prefixes with one regex each left gaps — `<chart c`, `<cite ref=`, and
+ * every state from the attribute's closing quote through the final `>` — and each
+ * gap dumped the raw tag into the DOM for a few frames before snapping back to the
+ * placeholder. For charts that meant flashing the whole JSON config as text.
+ *
+ * Anchor on the tag name instead: starting at the last `<name`, scan for the `>`
+ * that closes it. Quoted attribute values are skipped, because a chart title may
+ * legitimately contain `>`. Finding that `>` means the tag arrived in full and is
+ * left alone — so prose that merely mentions `<chart>` is untouched. Running off
+ * the end of the content instead means the tag is still streaming, and only then
+ * is it replaced.
+ *
+ * @param {string} content - Raw content being streamed
+ * @param {string} name - Tag name to look for, e.g. "chart"
+ * @param {string} placeholder - Markup to substitute for the partial tag
+ * @returns {string} Content with any in-flight tag replaced
+ */
+const hideStreamingTag = (content, name, placeholder) => {
+  // Match on the original string: indexing a lowercased copy is unsafe because
+  // toLowerCase is not length-preserving for every code point.
+  let open = -1;
+  for (const match of content.matchAll(new RegExp(`<${name}\\b`, "gi"))) {
+    open = match.index;
+  }
+  if (open === -1) return content;
+
+  let quote = null;
+  for (let i = open + name.length + 1; i < content.length; i++) {
+    const char = content[i];
+    if (quote) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return content; // tag is closed, so it is not mid-flight
+    }
+  }
+
+  return content.slice(0, open) + placeholder;
+};
+
+/**
  * Preprocess content to convert XML-style citations to URL-based citations
  * Format: <cite ref="X:Y" /> or <cite ref="X:Y,Z:W" />
  * Converted to: <cite data-urls="resolved_url1,resolved_url2"></cite>
@@ -324,6 +370,9 @@ const preprocessCitations = (content, webSearchResults) => {
   if (!content) return content;
 
   let processed = content;
+
+  // Hide a citation that is still arriving, before the rewrite below sees it
+  processed = hideStreamingTag(processed, "cite", CITATION_PLACEHOLDER);
 
   // Convert XML-style citations <cite ref="X:Y" /> or <cite ref="X:Y,Z:W" />
   processed = processed.replace(/<cite\s+ref="([^"]+)"\s*\/>/gi, (match, refContent) => {
@@ -340,14 +389,10 @@ const preprocessCitations = (content, webSearchResults) => {
     return match;
   });
 
-  // Replace incomplete citation patterns with a loading placeholder
-  // This handles all streaming states: <c, <ci, <cit, <cite, <cite , <cite r, <cite ref, <cite ref=, <cite ref="..., etc.
-  // Match incomplete <cite tags that haven't been closed with />
-  processed = processed.replace(/<cite(?:\s+ref(?:="[^"]*)?)?(?:\s*)$/gi, CITATION_PLACEHOLDER);
-
-  // Also catch partial tag starts like <c, <ci, <cit at the end
-  processed = processed.replace(/<cit?e?$/gi, CITATION_PLACEHOLDER);
-  processed = processed.replace(/<ci$/gi, CITATION_PLACEHOLDER);
+  // Partial tag names too short for hideStreamingTag to anchor on: <ci, <cit.
+  // A trailing <c is ambiguous with <chart, and is claimed here because citations
+  // are far more common and their placeholder is a small inline shimmer.
+  processed = processed.replace(/<cit?$/gi, CITATION_PLACEHOLDER);
   processed = processed.replace(/<c$/gi, CITATION_PLACEHOLDER);
 
   // Hide lone < at the end (could be start of any tag)
@@ -391,6 +436,9 @@ const preprocessCharts = (content) => {
 
   let processed = content;
 
+  // Hide a chart that is still arriving, before the rewrites below see it
+  processed = hideStreamingTag(processed, "chart", CHART_PLACEHOLDER);
+
   // Replace complete self-closing chart tags with single quotes: <chart config='...' />
   processed = processed.replace(/<chart\s+config='([^']+)'\s*\/>/gi, (match, configJson) => {
     return `<chart data-config="${escapeHtmlAttr(configJson)}"></chart>`;
@@ -411,23 +459,8 @@ const preprocessCharts = (content) => {
     return `<chart data-config="${escapeHtmlAttr(configJson)}"></chart>`;
   });
 
-  // Replace incomplete chart tags with placeholder
-  // Handle: <chart config='... (incomplete JSON, no closing quote or />)
-  processed = processed.replace(/<chart\s+config='[^']*$/gi, CHART_PLACEHOLDER);
-  // Handle: <chart config="... (incomplete JSON, no closing quote or />)
-  processed = processed.replace(/<chart\s+config="[^"]*$/gi, CHART_PLACEHOLDER);
-  // Handle: <chart config= (no quote yet)
-  processed = processed.replace(/<chart\s+config=\s*$/gi, CHART_PLACEHOLDER);
-  // Handle: <chart config (no = yet)
-  processed = processed.replace(/<chart\s+config\s*$/gi, CHART_PLACEHOLDER);
-  // Handle: <chart confi, <chart conf, etc.
-  processed = processed.replace(/<chart\s+conf?i?g?\s*$/gi, CHART_PLACEHOLDER);
-  // Handle: <chart (just the tag name with optional space)
-  processed = processed.replace(/<chart\s*$/gi, CHART_PLACEHOLDER);
-  // Handle: <char (partial tag name)
-  processed = processed.replace(/<char$/gi, CHART_PLACEHOLDER);
-  // Handle: <cha (partial tag name)
-  processed = processed.replace(/<cha$/gi, CHART_PLACEHOLDER);
+  // Partial tag names too short for hideStreamingTag to anchor on: <ch, <cha, <char
+  processed = processed.replace(/<ch(?:a(?:r)?)?$/gi, CHART_PLACEHOLDER);
 
   return processed;
 };

--- a/src/components/Agent/ThinkingBudget.jsx
+++ b/src/components/Agent/ThinkingBudget.jsx
@@ -1,68 +1,26 @@
 import React from "react";
-import List from "@cloudscape-design/components/list";
-import Toggle from "@cloudscape-design/components/toggle";
+import EffortSlider from "../EffortSlider";
 
-const ThinkingBudget = React.memo(({ budget, setBudget }) => {
-  const items = [
-    {
-      id: "1",
-      content: "Low",
-    },
-    {
-      id: "2",
-      content: "Medium",
-    },
-    {
-      id: "3",
-      content: "High",
-    },
-    {
-      id: "4",
-      content: "Max",
-    },
-  ];
-
-  const handleToggleChange = (itemId, isChecked) => {
-    // If toggling on, set this item as the budget
-    // If toggling off, clear the budget (optional - you might want to prevent this)
-    if (isChecked) {
-      setBudget(itemId);
-    } else {
-      // Optional: prevent unchecking the current selection
-      // or allow clearing by setting to null
-      setBudget(null);
-    }
-  };
-
+/**
+ * Sentry's reasoning-effort picker, shown in the Think button's dropdown.
+ *
+ * Thinking is always on — the lever only selects how much. Budget is held as a
+ * string ("1".."4") because it is persisted to localStorage and sent as-is.
+ */
+function ThinkingBudgetControl({ budget, setBudget }) {
   return (
     <div
       style={{
-        padding: "6px",
-        paddingRight: "16px",
-        paddingLeft: "10px",
-        width: "200px",
+        padding: "10px 16px 12px 12px",
+        width: "220px",
         fontSize: "14px",
       }}
     >
-      <List
-        ariaLabel="List with icons and actions"
-        sortable
-        sortDisabled
-        items={items}
-        renderItem={(item) => ({
-          id: item.id,
-          content: item.content,
-          actions: (
-            <Toggle
-              onChange={({ detail }) => handleToggleChange(item.id, detail.checked)}
-              checked={budget === item.id}
-              readOnly={budget === item.id}
-            />
-          ),
-        })}
-      />
+      <EffortSlider value={budget} onChange={(value) => setBudget(String(value))} />
     </div>
   );
-});
+}
+
+const ThinkingBudget = React.memo(ThinkingBudgetControl);
 
 export default ThinkingBudget;

--- a/src/components/Agent/context/sessionHelpers.js
+++ b/src/components/Agent/context/sessionHelpers.js
@@ -151,6 +151,10 @@ export const getSessionRefs = (sessionId, sessionRefs) => {
       buffer: [],
       bufferTimeout: null,
       rafId: null,
+      // Typewriter pump state (see the block below).
+      rate: 0, // smoothed chars/frame
+      acc: 0, // fractional char accumulator
+      netDone: false, // network stream finished (may still be revealing)
     });
   }
   return sessionRefs.current.get(sessionId);
@@ -179,12 +183,56 @@ export const setSessionLoading = (sessionId, setLoadingStates, isLoading) => {
   });
 };
 
-export const flushBuffer = (sessionId, sessionRefs, setSessions) => {
-  const refs = getSessionRefs(sessionId, sessionRefs);
-  if (!refs.buffer || refs.buffer.length === 0) return;
+// --- smooth text reveal (typewriter pump) ------------------------------------
+// The network delivers tokens in BURSTS (one packet is often dozens of tokens).
+// Batching them per frame — which is all the previous implementation did — still
+// pops a whole burst into view at once. Instead we treat the buffer as a QUEUE
+// and reveal characters at a steady, smoothed rate every frame, decoupled from
+// arrival, so text types out evenly instead of lurching.
+//
+// The rate is a low-pass-filtered function of the backlog, so it eases up and
+// down rather than snapping between fast and slow (that snapping is what reads
+// as burst-then-pause), with a fractional accumulator so sub-1-char/frame speeds
+// work. Reasoning ("think") is metered like answer text: it streams as summaries
+// emitted when a raw-thinking segment completes, so it arrives in paragraph-sized
+// bursts that would otherwise appear all at once. Tool and interrupt chunks pass
+// through in order, unmetered.
+//
+// Tuning: DRAIN_FRAMES is how many frames to nominally spread the current
+// backlog over (bigger = more cushion = fewer pauses). The rate is clamped so it
+// never trickles to a stop mid-answer (MIN) nor bursts (MAX), and eased toward
+// its target by SMOOTH (smaller = smoother).
+//
+// REVEAL_MAX only has to sit above the fastest rate the network can feed us. In
+// steady state the backlog term governs (at 100 chars/s arrival the queue holds
+// ~100 chars and the rate settles at ~100 chars/s), so the ceiling is reached
+// only on a burst — where catching up quickly is the desired behaviour. It used
+// to be 6 (~360 chars/s), which is *below* peak generation, so on a long answer
+// the queue grew without bound and a 20k-char reply kept typing for the better
+// part of a minute after the stream had already finished.
+const DRAIN_FRAMES = 60; // ~1s of cushion at 60fps
+const REVEAL_MIN = 0.6; // ~36 chars/s floor while content remains
+const REVEAL_MAX = 120; // ~7200 chars/s ceiling, above any real stream
+const SMOOTH = 0.08; // rate low-pass factor
 
-  const bufferedMessages = [...refs.buffer];
-  refs.buffer = [];
+// Chunks the pump reveals character-by-character. "[empty]" is a control marker
+// that groupMessages drops, so it must not be sliced.
+const isMetered = (chunk) =>
+  (chunk.type === "text" || chunk.type === "think") &&
+  typeof chunk.content === "string" &&
+  chunk.content !== "[empty]";
+
+const pendingChars = (queue) => {
+  let n = 0;
+  for (const chunk of queue) {
+    if (isMetered(chunk)) n += chunk.content.length;
+  }
+  return n;
+};
+
+/** Merge revealed chunks into the session's last turn and re-group its blocks. */
+const applyMessages = (sessionId, setSessions, bufferedMessages) => {
+  if (bufferedMessages.length === 0) return;
 
   setSessions((prev) => {
     const newSessions = new Map(prev);
@@ -215,18 +263,122 @@ export const flushBuffer = (sessionId, sessionRefs, setSessions) => {
   });
 };
 
-const scheduleBufferFlush = (sessionId, sessionRefs, setSessions, flushBufferFn) => {
+/** Settle isStreaming once the queue is empty AND the network is done. */
+const finishIfDrained = (sessionId, sessionRefs, setSessions) => {
   const refs = getSessionRefs(sessionId, sessionRefs);
+  if (refs.buffer.length === 0 && refs.netDone) {
+    refs.rate = 0;
+    refs.acc = 0;
+    updateSession(sessionId, setSessions, { isStreaming: false });
+  }
+};
 
-  // Cancel any previously scheduled animation frame for this session
+/**
+ * Reveal everything still queued, immediately and unmetered.
+ *
+ * Used on teardown, explicit stop, and while the tab is hidden — the animation
+ * is a foreground nicety, and replaying a backlog at reveal rate after the user
+ * returns would look like live generation long after the run finished.
+ */
+export const flushBuffer = (sessionId, sessionRefs, setSessions) => {
+  const refs = getSessionRefs(sessionId, sessionRefs);
   if (refs.rafId !== null) {
     cancelAnimationFrame(refs.rafId);
+    refs.rafId = null;
+  }
+  if (!refs.buffer || refs.buffer.length === 0) return;
+
+  const remaining = refs.buffer;
+  refs.buffer = [];
+  applyMessages(sessionId, setSessions, remaining);
+};
+
+/** One frame of metered reveal; reschedules itself while anything remains. */
+const pumpBuffer = (sessionId, sessionRefs, setSessions) => {
+  const refs = getSessionRefs(sessionId, sessionRefs);
+  refs.rafId = null;
+
+  const queue = refs.buffer;
+  if (queue.length === 0) {
+    finishIfDrained(sessionId, sessionRefs, setSessions);
+    return;
   }
 
-  // Schedule new animation frame
-  refs.rafId = requestAnimationFrame(() => {
-    refs.rafId = null;
-    flushBufferFn(sessionId, sessionRefs, setSessions);
+  // Ease the reveal rate toward a target derived from the backlog. Only floor to
+  // MIN while text is actually pending, so it keeps trickling steadily rather
+  // than stalling; near the end, MIN drains the last few characters.
+  //
+  // The ceiling exists to pace against an ongoing stream. Once the network is
+  // done there is nothing left to pace against, so the tail drains over
+  // DRAIN_FRAMES regardless of how much is queued — otherwise finishing a long
+  // answer would take longer than generating it did.
+  const pending = pendingChars(queue);
+  const ideal = pending / DRAIN_FRAMES;
+  const target = pending > 0 ? (refs.netDone ? ideal : Math.min(REVEAL_MAX, ideal)) : 0;
+  refs.rate += (target - refs.rate) * SMOOTH;
+  let effRate = refs.rate;
+  if (pending > 0 && effRate < REVEAL_MIN) effRate = REVEAL_MIN;
+
+  // Accumulate fractional chars; reveal the whole-number part this frame.
+  refs.acc += effRate;
+  let budget = Math.floor(refs.acc);
+  refs.acc -= budget;
+
+  const emit = [];
+  while (queue.length > 0) {
+    const head = queue[0];
+    if (isMetered(head)) {
+      if (budget <= 0) break;
+      if (head.content.length <= budget) {
+        emit.push(head);
+        budget -= head.content.length;
+        queue.shift();
+      } else {
+        // Reveal a slice; leave the remainder at the head for the next frame.
+        // groupMessages concatenates consecutive same-type chunks, so splitting
+        // one chunk into several renders identically.
+        emit.push({ ...head, content: head.content.slice(0, budget) });
+        queue[0] = { ...head, content: head.content.slice(budget) };
+        break;
+      }
+    } else {
+      // Tool / interrupt / end markers: pass through in order, unmetered.
+      emit.push(head);
+      queue.shift();
+    }
+  }
+
+  applyMessages(sessionId, setSessions, emit);
+
+  if (queue.length > 0) {
+    refs.rafId = requestAnimationFrame(() => pumpBuffer(sessionId, sessionRefs, setSessions));
+  } else {
+    finishIfDrained(sessionId, sessionRefs, setSessions);
+  }
+};
+
+const ensurePump = (sessionId, sessionRefs, setSessions) => {
+  const refs = getSessionRefs(sessionId, sessionRefs);
+  if (refs.rafId === null) {
+    refs.rafId = requestAnimationFrame(() => pumpBuffer(sessionId, sessionRefs, setSessions));
+  }
+};
+
+/** Drop any scheduled typewriter frame in every session (teardown). */
+export const cancelAllPumps = (sessionRefs) => {
+  sessionRefs.current.forEach((refs) => {
+    if (refs.rafId !== null) {
+      cancelAnimationFrame(refs.rafId);
+      refs.rafId = null;
+    }
+  });
+};
+
+/** Drain every session's backlog — used when the tab's visibility flips. */
+export const drainAllSessions = (sessionRefs, setSessions) => {
+  sessionRefs.current.forEach((_refs, sessionId) => {
+    flushBuffer(sessionId, sessionRefs, setSessions);
+    finishIfDrained(sessionId, sessionRefs, setSessions);
   });
 };
 
@@ -255,12 +407,32 @@ export const addAiMessage = (sessionId, message, sessionRefs, setSessions, flush
 
   refs.buffer.push(message);
 
-  // Use requestAnimationFrame for all message types for smooth, unified rendering
-  // RAF batches updates to the next frame (~16ms at 60fps), preventing jank
-  scheduleBufferFlush(sessionId, sessionRefs, setSessions, flushBufferFn);
+  if (document.hidden) {
+    // Hidden tabs get no animation frames, so the pump would stall while chunks
+    // keep queueing. Reveal immediately instead — see flushBuffer.
+    flushBufferFn(sessionId, sessionRefs, setSessions);
+    finishIfDrained(sessionId, sessionRefs, setSessions);
+  } else {
+    ensurePump(sessionId, sessionRefs, setSessions);
+  }
 };
 
-export const cleanupSSE = (sessionId, sessionRefs, setSessions, flushBufferFn) => {
+/**
+ * Tear down a session's stream.
+ *
+ * @param {boolean} immediate - Reveal the remaining backlog at once instead of
+ *   letting the pump type it out. Set this when the user asked the stream to
+ *   STOP: continuing to type afterwards contradicts the button they just
+ *   pressed, and because isStreaming is already false the composer is live, so
+ *   they can send a new message while the old answer is still appearing.
+ */
+export const cleanupSSE = (
+  sessionId,
+  sessionRefs,
+  setSessions,
+  flushBufferFn,
+  immediate = false
+) => {
   const refs = getSessionRefs(sessionId, sessionRefs);
 
   if (refs.eventSource) {
@@ -268,20 +440,22 @@ export const cleanupSSE = (sessionId, sessionRefs, setSessions, flushBufferFn) =
     refs.eventSource = null;
   }
 
-  // Flush any remaining buffered tokens before cleanup
-  flushBufferFn(sessionId, sessionRefs, setSessions);
-
   // Cancel any pending setTimeout for tool messages
   if (refs.bufferTimeout) {
     clearTimeout(refs.bufferTimeout);
     refs.bufferTimeout = null;
   }
 
-  // Cancel any pending requestAnimationFrame
-  if (refs.rafId !== null) {
-    cancelAnimationFrame(refs.rafId);
-    refs.rafId = null;
+  // The network is done, but text may still be revealing. Mark it and let the
+  // pump type out the tail, settling isStreaming when the queue drains. With a
+  // hidden tab (no frames) or nothing left, reveal and settle right away.
+  refs.netDone = true;
+
+  if (immediate || document.hidden || refs.buffer.length === 0) {
+    flushBufferFn(sessionId, sessionRefs, setSessions);
+    finishIfDrained(sessionId, sessionRefs, setSessions);
+    return;
   }
 
-  updateSession(sessionId, setSessions, { isStreaming: false });
+  ensurePump(sessionId, sessionRefs, setSessions);
 };

--- a/src/components/Agent/hooks/useSessionPreparation.js
+++ b/src/components/Agent/hooks/useSessionPreparation.js
@@ -23,8 +23,8 @@ export function useSessionPreparation({ sessionId, tools, thinkingBudget }) {
     return `${uuid}-${timestamp}-${randomSuffix}`;
   });
 
-  // Convert thinkingBudget value
-  const processedThinkingBudget = thinkingBudget === false ? 0 : thinkingBudget;
+  // Effort levels run 1-4; thinking is always on, so there is no 0 to map.
+  const processedThinkingBudget = thinkingBudget || 1;
 
   // JSON-only parsing function
   const parseToolString = useCallback((toolString) => {

--- a/src/components/Agent/useAgentState.js
+++ b/src/components/Agent/useAgentState.js
@@ -1,14 +1,21 @@
 import { useReducer, useCallback } from "react";
 
 const STORAGE_KEYS = {
-  THINKING_ENABLED: "thinkingEnabled",
   THINKING_BUDGET: "thinkingBudget",
   TOOLS_CONFIG: "toolsConfig",
 };
 
+// Effort levels run 1-4; there is no "off" level. A persisted "0" from an
+// earlier version (when thinking could be disabled) falls back to the minimum.
+const VALID_BUDGETS = ["1", "2", "3", "4"];
+
+const readStoredBudget = () => {
+  const stored = localStorage.getItem(STORAGE_KEYS.THINKING_BUDGET);
+  return VALID_BUDGETS.includes(stored) ? stored : "1";
+};
+
 const createInitialState = () => ({
-  budget: localStorage.getItem(STORAGE_KEYS.THINKING_BUDGET) || "1",
-  thinkingEnabled: localStorage.getItem(STORAGE_KEYS.THINKING_ENABLED) !== "false",
+  budget: readStoredBudget(),
   toolItems: [],
   toolsInitialized: false,
   isFirstMountComplete: false,
@@ -19,9 +26,6 @@ function agentReducer(state, action) {
     case "SET_BUDGET":
       localStorage.setItem(STORAGE_KEYS.THINKING_BUDGET, action.payload);
       return { ...state, budget: action.payload };
-    case "SET_THINKING_ENABLED":
-      localStorage.setItem(STORAGE_KEYS.THINKING_ENABLED, String(action.payload));
-      return { ...state, thinkingEnabled: action.payload };
     case "SET_TOOL_ITEMS":
       return { ...state, toolItems: action.payload, toolsInitialized: true };
     case "SET_FIRST_MOUNT_COMPLETE":
@@ -36,13 +40,6 @@ export function useAgentState() {
 
   const setBudget = useCallback((budget) => {
     dispatch({ type: "SET_BUDGET", payload: budget });
-    if (budget !== "0") {
-      dispatch({ type: "SET_THINKING_ENABLED", payload: true });
-    }
-  }, []);
-
-  const setThinkingEnabled = useCallback((enabled) => {
-    dispatch({ type: "SET_THINKING_ENABLED", payload: enabled });
   }, []);
 
   const setToolItems = useCallback((items) => {
@@ -61,7 +58,6 @@ export function useAgentState() {
   return {
     state,
     setBudget,
-    setThinkingEnabled,
     setToolItems,
     setFirstMountComplete,
     dispatch,

--- a/src/components/Agent/useChatSessionFunctions.js
+++ b/src/components/Agent/useChatSessionFunctions.js
@@ -158,6 +158,15 @@ export const useChatSessionFunctions = (props) => {
         if (refs.bufferTimeout) {
           clearTimeout(refs.bufferTimeout);
         }
+        // Drop any scheduled typewriter frame. Without this the queued rAF still
+        // fires after the delete, and getSessionRefs re-inserts a fresh entry for
+        // the session that just went away — a leaked map entry per removal, plus
+        // a setSessions for a session that no longer exists.
+        if (refs.rafId !== null && refs.rafId !== undefined) {
+          cancelAnimationFrame(refs.rafId);
+          refs.rafId = null;
+        }
+        refs.buffer = [];
         sessionRefs.current.delete(sessionId);
       }
 
@@ -422,6 +431,14 @@ export const useChatSessionFunctions = (props) => {
         });
       }
 
+      // Reset the typewriter pump for this run: a previous run left netDone set
+      // (and a settled rate), which would make the first chunk of this one
+      // settle isStreaming immediately.
+      const pumpRefs = getSessionRefs(sessionId, sessionRefs);
+      pumpRefs.netDone = false;
+      pumpRefs.rate = 0;
+      pumpRefs.acc = 0;
+
       try {
         const response = await sendMessageAPI(
           sessionId,
@@ -624,7 +641,9 @@ export const useChatSessionFunctions = (props) => {
           error: null,
           isStreaming: false,
         });
-        cleanupSSE(sessionId, sessionRefs, setSessions, flushBuffer);
+        // immediate: the user pressed Stop, so reveal what already arrived
+        // instead of typing it out after the fact.
+        cleanupSSE(sessionId, sessionRefs, setSessions, flushBuffer, true);
         return data;
       } catch (error) {
         console.error(`Failed to stop ${sessionId}:`, error);

--- a/src/components/Agent/utils/constants.js
+++ b/src/components/Agent/utils/constants.js
@@ -1,4 +1,6 @@
-export const WEB_SEARCH_TOOLS = ["tavily_search", "remote_web_search"];
+// "web_search" is the AgentCore connector tool (see
+// backend/sentry/web_search_tools.py); it has no extract counterpart.
+export const WEB_SEARCH_TOOLS = ["tavily_search", "remote_web_search", "web_search"];
 export const WEB_EXTRACT_TOOLS = ["tavily_extract", "webFetch"];
 export const THREAT_TOOLS = ["add_threats", "edit_threats", "delete_threats", "remove_threat"];
 

--- a/src/components/EffortSlider.css
+++ b/src/components/EffortSlider.css
@@ -1,0 +1,229 @@
+/* The reasoning-effort lever, ported from the data wiki agent's "Faster ↔
+   Smarter" control. A native range input drives it (keyboard + a11y for free)
+   but is overlaid transparently; the visible parts are painted here:
+
+   - TRACK  — the unfilled base: a taller pill carrying a repeating dot field,
+              no colour.
+   - FILL   — spans start→thumb only. It paints the light→dark gradient sized to
+              calc(100% / frac) so the gradient maps across the WHOLE track and
+              the fill (only `frac` wide) reveals just the 0→thumb slice. That is
+              what keeps the fill a continuous fade instead of a flat block.
+              A brighter dot field tiles over it.
+   - THUMB  — a white puck.
+
+   --effort-frac (0..1) is set inline by the component. */
+
+.effort-slider {
+  --effort-thumb-w: 14px;
+  --effort-track-h: 18px;
+  --effort-track-base: rgb(0 0 0 / 0.08);
+  /* Kept faint on purpose: the pill shape comes from --effort-track-base, so the
+     dots only need to hint at texture. Much above this they read as a hard grid
+     and compete with the filled portion. */
+  --effort-track-dot: rgb(0 0 0 / 0.15);
+  /* Dots over the fill are a light tint, not a dark one: black dots read as a
+     mesh laid on top and muddy the gradient, while white at low alpha keeps the
+     brand colours vivid and lets the texture recede. */
+  --effort-fill-dot: rgb(255 255 255 / 0.22);
+  /* The Threat Designer logo gradient (see Agent/AgentLogo.jsx): pale sky ->
+     blue -> violet -> purple. It already runs light at the Faster end and
+     saturated at the Smarter end, which is exactly the swing this control wants.
+     Keep the stops in sync with the logo. */
+  --effort-fill-0: #b8e7ff;
+  --effort-fill-25: #0099ff;
+  --effort-fill-40: #5c7fff;
+  --effort-fill-60: #8575ff;
+  --effort-fill-100: #962eff;
+  --effort-accent: #8575ff;
+}
+
+.awsui-dark-mode .effort-slider {
+  --effort-track-base: rgb(255 255 255 / 0.1);
+  --effort-track-dot: rgb(255 255 255 / 0.16);
+  /* The logo ramp with its two ends retuned for a dark surface: the near-white
+     start (#b8e7ff) glares against a dark card, so it deepens to a saturated
+     sky, and the purple end lifts slightly so it doesn't sink into the
+     background. The violet mids are the logo's own and carry the brand path. */
+  --effort-fill-0: #6fd2f7;
+  --effort-fill-25: #0d9bf5;
+  --effort-fill-100: #9a3aff;
+  /* Accent lifted so the level name keeps enough contrast on dark. */
+  --effort-accent: #a89bff;
+}
+
+/* -- header: "Effort <Level>", level in the accent ------------------------- */
+
+.effort-slider__header {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.3;
+  margin-bottom: 10px;
+}
+
+.effort-slider__level {
+  color: var(--effort-accent);
+  font-weight: 700;
+  /* Clipping container for the roll swap. */
+  position: relative;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: bottom;
+  text-transform: capitalize;
+}
+
+.effort-slider__level-in {
+  display: inline-block;
+  animation: effort-roll-in 260ms ease-out;
+}
+
+.effort-slider__level-out {
+  position: absolute;
+  inset: 0;
+  display: inline-block;
+  animation: effort-roll-out 260ms ease-out forwards;
+}
+
+/* No roll on first paint — only on a change (the component keys the span on a
+   generation counter that starts at 0). */
+.effort-slider__level-in--initial {
+  animation: none;
+}
+
+@keyframes effort-roll-in {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes effort-roll-out {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .effort-slider__level-in,
+  .effort-slider__level-out {
+    animation: none;
+  }
+}
+
+/* -- end labels ------------------------------------------------------------ */
+
+.effort-slider__ends {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  line-height: 1;
+  margin-bottom: 3px;
+  color: rgb(0 0 0 / 0.55);
+}
+
+.awsui-dark-mode .effort-slider__ends {
+  color: rgb(255 255 255 / 0.6);
+}
+
+/* -- track / fill / thumb -------------------------------------------------- */
+
+.effort-slider__rail {
+  position: relative;
+  height: var(--effort-track-h);
+  padding: 2px 0;
+}
+
+.effort-slider__track {
+  position: absolute;
+  inset: 0;
+  height: var(--effort-track-h);
+  border-radius: 6px;
+  background-color: var(--effort-track-base);
+  background-image: radial-gradient(
+    circle at center,
+    var(--effort-track-dot) 0.9px,
+    transparent 1.2px
+  );
+  background-size: 6px 6px;
+  background-repeat: repeat;
+}
+
+.effort-slider__fill {
+  --_frac: var(--effort-frac, 0.0001);
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: var(--effort-track-h);
+  /* Reach the thumb's centre: the thumb travels (100% - thumb width). */
+  width: calc(var(--_frac) * (100% - var(--effort-thumb-w)) + var(--effort-thumb-w) / 2);
+  border-radius: 6px 0 0 6px;
+  background-color: transparent;
+  background-image:
+    radial-gradient(circle at center, var(--effort-fill-dot) 0.9px, transparent 1.2px),
+    linear-gradient(
+      to right,
+      var(--effort-fill-0) 0%,
+      var(--effort-fill-25) 25%,
+      var(--effort-fill-40) 40%,
+      var(--effort-fill-60) 60%,
+      var(--effort-fill-100) 100%
+    );
+  background-size:
+    6px 6px,
+    calc(100% / var(--_frac)) 100%;
+  background-position:
+    0 0,
+    left center;
+  background-repeat: repeat, no-repeat;
+}
+
+.effort-slider__thumb {
+  --_frac: var(--effort-frac, 0);
+  position: absolute;
+  top: 50%;
+  left: calc(var(--_frac) * (100% - var(--effort-thumb-w)));
+  width: var(--effort-thumb-w);
+  height: 22px;
+  transform: translateY(-50%);
+  border-radius: 5px;
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.35);
+  pointer-events: none;
+}
+
+/* The real control: transparent, on top, full-size. */
+.effort-slider__input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.effort-slider__input:disabled {
+  cursor: default;
+}
+
+.effort-slider--readonly .effort-slider__input {
+  cursor: default;
+}
+
+/* Keyboard focus only. Focus lands on the invisible input, so the ring has to be
+   surfaced on the track — but scoping it to :focus-visible keeps it off the way
+   when the control is clicked or dragged with a pointer. */
+.effort-slider__rail:has(.effort-slider__input:focus-visible) .effort-slider__track {
+  outline: 2px solid var(--effort-accent);
+  outline-offset: 2px;
+}

--- a/src/components/EffortSlider.jsx
+++ b/src/components/EffortSlider.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useRef, useState } from "react";
+import "./EffortSlider.css";
+
+/**
+ * The shared reasoning-effort lever, ported from the data wiki agent's control:
+ * a "Faster <-> Smarter" stepped slider on a dotted pill track whose fill fades
+ * light->dark up to a white puck, with the selected level named above it and
+ * rolled in on change.
+ *
+ * Used by both Sentry's Think dropdown and the threat modeling wizard so the two
+ * read the same. Levels run 1-4 — there is no "off": every current model is a
+ * reasoning model, and on Claude Opus 5 thinking cannot be disabled above effort
+ * "high" (see backend/threat_designer/constants.py).
+ */
+
+export const MIN_EFFORT = 1;
+export const MAX_EFFORT = 4;
+
+// "Extra" rather than "xhigh"/"Extra High": xhigh is the wire value the runtime
+// expects but it reads badly in a UI. Label-only — never sent to the API.
+export const EFFORT_LEVELS = [
+  { value: 1, label: "Low" },
+  { value: 2, label: "Medium" },
+  { value: 3, label: "High" },
+  { value: 4, label: "Extra" },
+];
+
+export const effortLabel = (value) =>
+  EFFORT_LEVELS.find((level) => level.value === Number(value))?.label ?? "";
+
+const clamp = (value) => {
+  const n = Number(value);
+  if (Number.isNaN(n)) return MIN_EFFORT;
+  return Math.min(Math.max(Math.round(n), MIN_EFFORT), MAX_EFFORT);
+};
+
+/** The level name, rolling the old value out below as the new one drops in. */
+function RollingLevel({ label }) {
+  const prevRef = useRef(label);
+  const [leaving, setLeaving] = useState(null);
+  // Increments only on a real change, so the enter animation runs exactly then
+  // and never on mount.
+  const [gen, setGen] = useState(0);
+
+  useEffect(() => {
+    const prev = prevRef.current;
+    if (prev === label) return undefined;
+    prevRef.current = label;
+    setLeaving(prev);
+    setGen((g) => g + 1);
+    const timer = setTimeout(() => setLeaving(null), 260);
+    return () => clearTimeout(timer);
+  }, [label]);
+
+  return (
+    <span className="effort-slider__level">
+      <span
+        key={gen}
+        className={`effort-slider__level-in${gen === 0 ? " effort-slider__level-in--initial" : ""}`}
+      >
+        {label}
+      </span>
+      {leaving != null && (
+        <span key={`out-${gen}`} aria-hidden="true" className="effort-slider__level-out">
+          {leaving}
+        </span>
+      )}
+    </span>
+  );
+}
+
+const EffortSlider = ({ value, onChange, showHeader = true, readOnly = false }) => {
+  const level = clamp(value);
+  // Filled fraction 0..1 across the available stops.
+  const frac = (level - MIN_EFFORT) / (MAX_EFFORT - MIN_EFFORT);
+
+  return (
+    <div
+      className={`effort-slider${readOnly ? " effort-slider--readonly" : ""}`}
+      style={{ "--effort-frac": frac || 0.0001 }}
+    >
+      {showHeader && (
+        <div className="effort-slider__header">
+          Effort <RollingLevel label={effortLabel(level)} />
+        </div>
+      )}
+      <div className="effort-slider__ends">
+        <span>Faster</span>
+        <span>Smarter</span>
+      </div>
+      <div className="effort-slider__rail">
+        <div className="effort-slider__track" />
+        <div className="effort-slider__fill" />
+        <div className="effort-slider__thumb" />
+        <input
+          className="effort-slider__input"
+          type="range"
+          min={MIN_EFFORT}
+          max={MAX_EFFORT}
+          step={1}
+          value={level}
+          disabled={readOnly}
+          onChange={(event) => onChange?.(Number(event.target.value))}
+          aria-label="Reasoning effort"
+          aria-valuetext={effortLabel(level)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(EffortSlider);

--- a/src/components/ThreatModeling/AttackTree/nodes/CountermeasureNode.jsx
+++ b/src/components/ThreatModeling/AttackTree/nodes/CountermeasureNode.jsx
@@ -8,7 +8,10 @@ import "./NodeStyles.css";
 
 const CountermeasureNode = ({ data, selected, id }) => {
   return (
-    <div data-testid={`node-${id}`} className={`custom-node countermeasure-node ${selected ? "selected" : ""}`}>
+    <div
+      data-testid={`node-${id}`}
+      className={`custom-node countermeasure-node ${selected ? "selected" : ""}`}
+    >
       <Handle
         type="target"
         position={Position.Left}

--- a/src/components/ThreatModeling/AttackTree/nodes/RootGoalNode.jsx
+++ b/src/components/ThreatModeling/AttackTree/nodes/RootGoalNode.jsx
@@ -22,7 +22,10 @@ const RootGoalNode = ({ data, selected, id }) => {
   };
 
   return (
-    <div data-testid={`node-${id}`} className={`custom-node gate-node root-goal-node ${selected ? "selected" : ""}`}>
+    <div
+      data-testid={`node-${id}`}
+      className={`custom-node gate-node root-goal-node ${selected ? "selected" : ""}`}
+    >
       {/* Action Buttons - Only edit, no delete for root goal */}
       {!data.isReadOnly && (
         <div className="node-action-buttons">

--- a/src/components/ThreatModeling/ConflictResolutionModal.jsx
+++ b/src/components/ThreatModeling/ConflictResolutionModal.jsx
@@ -524,80 +524,82 @@ const ConflictResolutionModal = ({
       }
     >
       <div data-testid="conflict-modal">
-      <SpaceBetween size="m">
-        <Alert type="warning" header="Conflict detected">
-          The threat model has been modified by another user since you last loaded it. You can
-          review the differences below and choose how to proceed.
-        </Alert>
+        <SpaceBetween size="m">
+          <Alert type="warning" header="Conflict detected">
+            The threat model has been modified by another user since you last loaded it. You can
+            review the differences below and choose how to proceed.
+          </Alert>
 
-        <Tabs
-          activeTabId={activeTabId}
-          onChange={({ detail }) => setActiveTabId(detail.activeTabId)}
-          tabs={[
-            {
-              id: "overview",
-              label: "Overview",
-              content: (
-                <SpaceBetween size="m">
-                  <Container>
-                    <ColumnLayout columns={2} variant="text-grid">
-                      <div>
-                        <Box variant="awsui-key-label">Server Timestamp</Box>
-                        <div>{new Date(conflictData.server_timestamp).toLocaleString()}</div>
-                      </div>
-                      <div>
-                        <Box variant="awsui-key-label">Your Timestamp</Box>
-                        <div>{new Date(conflictData.client_timestamp).toLocaleString()}</div>
-                      </div>
-                      <div>
-                        <Box variant="awsui-key-label">Last Modified By</Box>
-                        <div>{serverState.last_modified_by || "Unknown"}</div>
-                      </div>
-                      <div>
-                        <Box variant="awsui-key-label">Total Differences</Box>
-                        <div>{totalDifferences}</div>
-                      </div>
-                    </ColumnLayout>
-                  </Container>
+          <Tabs
+            activeTabId={activeTabId}
+            onChange={({ detail }) => setActiveTabId(detail.activeTabId)}
+            tabs={[
+              {
+                id: "overview",
+                label: "Overview",
+                content: (
+                  <SpaceBetween size="m">
+                    <Container>
+                      <ColumnLayout columns={2} variant="text-grid">
+                        <div>
+                          <Box variant="awsui-key-label">Server Timestamp</Box>
+                          <div>{new Date(conflictData.server_timestamp).toLocaleString()}</div>
+                        </div>
+                        <div>
+                          <Box variant="awsui-key-label">Your Timestamp</Box>
+                          <div>{new Date(conflictData.client_timestamp).toLocaleString()}</div>
+                        </div>
+                        <div>
+                          <Box variant="awsui-key-label">Last Modified By</Box>
+                          <div>{serverState.last_modified_by || "Unknown"}</div>
+                        </div>
+                        <div>
+                          <Box variant="awsui-key-label">Total Differences</Box>
+                          <div>{totalDifferences}</div>
+                        </div>
+                      </ColumnLayout>
+                    </Container>
 
-                  <Alert type="info">
-                    <strong>What should I do?</strong>
-                    <ul>
-                      <li>
-                        <strong>Use Server Version:</strong> Discard your changes and use the latest
-                        version from the server
-                      </li>
-                      <li>
-                        <strong>Use My Version:</strong> Keep your changes and overwrite the server
-                        version (this will discard the other user's changes)
-                      </li>
-                    </ul>
-                  </Alert>
-                </SpaceBetween>
-              ),
-            },
-            {
-              id: "differences",
-              label: `Differences (${totalDifferences})`,
-              content: (
-                <SpaceBetween size="m">
-                  {renderDescriptionDiff()}
-                  {renderAssumptionDiffs()}
-                  {renderDiffSection("Threats", threatDiffs)}
-                  {renderDiffSection("Assets", assetDiffs)}
-                  {renderDiffSection("Data Flows", flowDiffs)}
-                  {renderDiffSection("Trust Boundaries", boundaryDiffs)}
-                  {renderDiffSection("Threat Sources", sourceDiffs)}
+                    <Alert type="info">
+                      <strong>What should I do?</strong>
+                      <ul>
+                        <li>
+                          <strong>Use Server Version:</strong> Discard your changes and use the
+                          latest version from the server
+                        </li>
+                        <li>
+                          <strong>Use My Version:</strong> Keep your changes and overwrite the
+                          server version (this will discard the other user's changes)
+                        </li>
+                      </ul>
+                    </Alert>
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: "differences",
+                label: `Differences (${totalDifferences})`,
+                content: (
+                  <SpaceBetween size="m">
+                    {renderDescriptionDiff()}
+                    {renderAssumptionDiffs()}
+                    {renderDiffSection("Threats", threatDiffs)}
+                    {renderDiffSection("Assets", assetDiffs)}
+                    {renderDiffSection("Data Flows", flowDiffs)}
+                    {renderDiffSection("Trust Boundaries", boundaryDiffs)}
+                    {renderDiffSection("Threat Sources", sourceDiffs)}
 
-                  {totalDifferences === 0 && (
-                    <Alert type="info">No differences detected in the main data structures.</Alert>
-                  )}
-                </SpaceBetween>
-              ),
-            },
-          ]}
-        />
-      </SpaceBetween>
+                    {totalDifferences === 0 && (
+                      <Alert type="info">
+                        No differences detected in the main data structures.
+                      </Alert>
+                    )}
+                  </SpaceBetween>
+                ),
+              },
+            ]}
+          />
+        </SpaceBetween>
       </div>
     </Modal>
   );

--- a/src/components/ThreatModeling/ReplayModal.jsx
+++ b/src/components/ThreatModeling/ReplayModal.jsx
@@ -10,8 +10,7 @@ import {
   Link,
 } from "@cloudscape-design/components";
 import Alert from "@cloudscape-design/components/alert";
-import { I18nProvider } from "@cloudscape-design/components/i18n";
-import Slider from "@cloudscape-design/components/slider";
+import EffortSlider from "../EffortSlider";
 import Textarea from "@cloudscape-design/components/textarea";
 
 export const ReplayModalComponent = ({
@@ -22,10 +21,9 @@ export const ReplayModalComponent = ({
   currentApplicationType = "hybrid",
 }) => {
   const [iteration, setIteration] = useState({ label: "Auto", value: 0 });
-  const [reasoning, setReasoning] = useState("0");
+  const [reasoning, setReasoning] = useState("1");
   const [text, setText] = useState(null);
   const [applicationType, setApplicationType] = useState(null);
-  const maxReasoning = 4;
 
   const applicationTypeOptions = [
     { label: "Internal", value: "internal" },
@@ -37,15 +35,6 @@ export const ReplayModalComponent = ({
     applicationType ||
     applicationTypeOptions.find((o) => o.value === currentApplicationType) ||
     applicationTypeOptions[1];
-
-  const reasoningLabels = [
-    { value: "0", label: "None" },
-    { value: "1", label: "Low" },
-    { value: "2", label: "Medium" },
-    { value: "3", label: "High" },
-    { value: "4", label: "Max" },
-  ];
-  const reasoningReferenceValues = [1, 2, 3];
 
   return (
     <Modal
@@ -112,19 +101,7 @@ export const ReplayModalComponent = ({
             label="Reasoning boost"
             description="Controls the amount of time the model spends thinking before responding."
           >
-            <Slider
-              i18nStrings={I18nProvider}
-              onChange={({ detail }) => setReasoning(detail.value)}
-              value={reasoning}
-              valueFormatter={(value) =>
-                reasoningLabels.find((item) => item.value === value.toString())?.label || ""
-              }
-              ariaDescription={"From None to Max"}
-              max={maxReasoning}
-              min={0}
-              referenceValues={reasoningReferenceValues}
-              step={1}
-            />
+            <EffortSlider value={reasoning} onChange={setReasoning} />
           </FormField>
           <FormField
             label="Application type"

--- a/src/components/ThreatModeling/SubmissionForm.jsx
+++ b/src/components/ThreatModeling/SubmissionForm.jsx
@@ -14,8 +14,7 @@ import {
   Box,
   Link,
 } from "@cloudscape-design/components";
-import { I18nProvider } from "@cloudscape-design/components/i18n";
-import Slider from "@cloudscape-design/components/slider";
+import EffortSlider from "../EffortSlider";
 import FileTokenGroup from "@cloudscape-design/components/file-token-group";
 import Textarea from "@cloudscape-design/components/textarea";
 import { listSpaces } from "../../services/Spaces/spacesService";
@@ -36,15 +35,6 @@ export const SubmissionComponent = ({
   reasoning,
   setReasoning,
 }) => {
-  const maxReasoning = 4;
-  const reasoningLabels = [
-    { value: "0", label: "None" },
-    { value: "1", label: "Low" },
-    { value: "2", label: "Medium" },
-    { value: "3", label: "High" },
-    { value: "4", label: "Max" },
-  ];
-  const reasoningReferenceValues = [1, 2, 3];
   const [activeStepIndex, setActiveStepIndex] = React.useState(0);
   // Primary diagram (required, exactly 1) is kept separate from the optional
   // aiding diagrams so the primary is always index 0 of the combined payload —
@@ -97,489 +87,467 @@ export const SubmissionComponent = ({
 
   return (
     <div data-testid="submission-wizard">
-    <Wizard
-      i18nStrings={{
-        stepNumberLabel: (stepNumber) => `Step ${stepNumber}`,
-        collapsedStepsLabel: (stepNumber, stepsCount) => `Step ${stepNumber} of ${stepsCount}`,
-        skipToButtonLabel: (step) => `Skip to ${step.title}`,
-        navigationAriaLabel: "Steps",
-        previousButton: "Previous",
-        nextButton: "Next",
-        optional: "optional",
-      }}
-      onNavigate={({ detail }) => {
-        if (detail.reason === "next") {
-          if (!primaryValue[0] && detail.requestedStepIndex === 2) {
-            setError(true);
-          } else if (title.length === 0 && detail.requestedStepIndex === 1) {
-            setError(true);
-          } else {
+      <Wizard
+        i18nStrings={{
+          stepNumberLabel: (stepNumber) => `Step ${stepNumber}`,
+          collapsedStepsLabel: (stepNumber, stepsCount) => `Step ${stepNumber} of ${stepsCount}`,
+          skipToButtonLabel: (step) => `Skip to ${step.title}`,
+          navigationAriaLabel: "Steps",
+          previousButton: "Previous",
+          nextButton: "Next",
+          optional: "optional",
+        }}
+        onNavigate={({ detail }) => {
+          if (detail.reason === "next") {
+            if (!primaryValue[0] && detail.requestedStepIndex === 2) {
+              setError(true);
+            } else if (title.length === 0 && detail.requestedStepIndex === 1) {
+              setError(true);
+            } else {
+              setError(false);
+              setActiveStepIndex(detail.requestedStepIndex);
+            }
+          }
+          if (detail.reason === "previous") {
             setError(false);
             setActiveStepIndex(detail.requestedStepIndex);
           }
-        }
-        if (detail.reason === "previous") {
-          setError(false);
-          setActiveStepIndex(detail.requestedStepIndex);
-        }
-      }}
-      activeStepIndex={activeStepIndex}
-      submitButtonText="Start threat modeling"
-      isLoadingNextStep={loading}
-      onSubmit={() => {
-        handleStart(
-          title,
-          text,
-          assumptions,
-          applicationType.value,
-          selectedSpaceOption?.value || null
-        );
-      }}
-      steps={[
-        {
-          title: "Title",
-          description: "Provide a meaningful title for the threat model.",
-          content: (
-            <div data-testid="wizard-step-title" style={{ minHeight: 200 }}>
-              <FormField errorText={error ? "Title is required." : null}>
-                <Input
-                  value={title}
-                  onChange={(event) => setTitle(event.detail.value)}
-                  ariaLabel="Threat model title"
-                />
-              </FormField>
-            </div>
-          ),
-        },
-        {
-          title: "Architecture diagram(s)",
-          description:
-            "Upload one primary architecture diagram (required). You can add up to 2 aiding diagrams (optional) to provide extra views — detailed, security layer, etc. Max 3.75 MB per file.",
-          content: (
-            <div style={{ minHeight: 200 }}>
-              <SpaceBetween size="l">
-                <FormField
-                  label="Primary architecture diagram"
-                  description="The main diagram. Used as the baseline when creating future versions of this threat model."
-                >
-                  <StartComponent
-                    onBase64Change={setPrimaryBase64}
-                    value={primaryValue}
-                    setValue={setPrimaryValue}
-                    error={error}
-                    setError={setError}
-                    maxFiles={1}
-                    buttonText="Choose primary diagram"
-                    constraintText={`PNG or JPG. Max ${MAX_FILE_SIZE_DISPLAY}.`}
-                    requiredErrorText="A primary architecture diagram is required before moving to the next step"
-                  />
-                </FormField>
-                <FormField
-                  label={
-                    <span>
-                      Aiding diagrams <i>- optional</i>
-                    </span>
-                  }
-                  description={`Additional views (detailed, security layer, etc.) to aid analysis. Up to ${MAX_AIDING_FILES} files.`}
-                >
-                  <StartComponent
-                    onBase64Change={setAidingBase64}
-                    value={aidingValue}
-                    setValue={setAidingValue}
-                    error={false}
-                    setError={() => {}}
-                    maxFiles={MAX_AIDING_FILES}
-                    buttonText="Choose aiding diagrams"
-                    constraintText={`Optional. Select up to ${MAX_AIDING_FILES} additional diagrams (PNG/JPG). Max ${MAX_FILE_SIZE_DISPLAY} per file.`}
-                  />
-                </FormField>
-              </SpaceBetween>
-            </div>
-          ),
-        },
-        {
-          title: "Details",
-          description: "Provide details about your application to help scope the threat model.",
-          content: (
-            <div style={{ minHeight: 200 }}>
-              <SpaceBetween size="s">
-                <FormField
-                  label="Application type"
-                  info={
-                    <Popover
-                      header="Application type"
-                      content={
-                        <SpaceBetween size="s">
-                          <Box>
-                            <Box variant="h5">Internal</Box>
-                            Accessible only within a private network. Reduced external threat
-                            exposure, but insider threats and misconfigurations remain relevant.
-                          </Box>
-                          <Box>
-                            <Box variant="h5">Hybrid</Box>
-                            Both internal and external-facing components. Public parts get full
-                            rigor, internal parts reflect reduced exposure.
-                          </Box>
-                          <Box>
-                            <Box variant="h5">Public facing</Box>
-                            Internet-facing, accessible by anonymous users. Subject to constant
-                            automated attacks and broad threat actor exposure.
-                          </Box>
-                        </SpaceBetween>
-                      }
-                    >
-                      <Link variant="info">Info</Link>
-                    </Popover>
-                  }
-                >
-                  <Select
-                    options={[
-                      { label: "Internal", value: "internal" },
-                      { label: "Hybrid", value: "hybrid" },
-                      { label: "Public facing", value: "public_facing" },
-                    ]}
-                    selectedOption={applicationType}
-                    onChange={({ detail }) => setApplicationType(detail.selectedOption)}
-                  />
-                </FormField>
-                <FormField
-                  label="Space"
-                  constraintText="Optional — attach a knowledge base to enrich threat modeling context."
-                  info={
-                    <Popover
-                      header="Spaces"
-                      content={
-                        <SpaceBetween size="s">
-                          <Box>
-                            A Space is a knowledge base you manage. Upload architecture docs,
-                            runbooks, or security policies and the agent will query them before
-                            threat modeling to surface relevant context.
-                          </Box>
-                          <Box>
-                            <Box variant="h5">What to upload</Box>
-                            Network diagrams, data classification docs, compliance requirements,
-                            existing security controls, or any reference material specific to your
-                            environment.
-                          </Box>
-                          <Box>
-                            <Box variant="h5">How it works</Box>
-                            Before analyzing your architecture, the agent queries the Space and
-                            injects relevant insights into the threat modeling process.
-                          </Box>
-                        </SpaceBetween>
-                      }
-                    >
-                      <Link variant="info">Info</Link>
-                    </Popover>
-                  }
-                >
-                  <Select
-                    options={[{ label: "None", value: null }, ...spaces]}
-                    selectedOption={selectedSpaceOption || { label: "None", value: null }}
-                    onChange={({ detail }) =>
-                      setSelectedSpaceOption(
-                        detail.selectedOption.value ? detail.selectedOption : null
-                      )
-                    }
-                    placeholder="Select a space (optional)"
-                  />
-                </FormField>
-                <FormField
-                  label="Description"
-                  info={
-                    <Popover
-                      header="Description tips"
-                      content={
-                        <SpaceBetween size="s">
-                          <Box>
-                            Use this field to provide context that can't be inferred from the
-                            architecture diagram alone. For example:
-                          </Box>
-                          <Box>
-                            <Box variant="h5">Data sensitivity</Box>
-                            What types of data does the system handle? (PII, financial records,
-                            health data, credentials)
-                          </Box>
-                          <Box>
-                            <Box variant="h5">User base and access</Box>
-                            Who uses the system? Internal employees, external customers, third-party
-                            partners?
-                          </Box>
-                          <Box>
-                            <Box variant="h5">Compliance requirements</Box>
-                            Any regulatory frameworks that apply? (GDPR, HIPAA, PCI-DSS, SOC 2)
-                          </Box>
-                          <Box>
-                            <Box variant="h5">Deployment context</Box>
-                            Cloud provider, on-premises, hybrid? Multi-region? Shared tenancy?
-                          </Box>
-                        </SpaceBetween>
-                      }
-                    >
-                      <Link variant="info">Info</Link>
-                    </Popover>
-                  }
-                >
-                  <Textarea
-                    onChange={({ detail }) => setText(detail.value)}
-                    value={text}
-                    placeholder="Add your description"
-                  />
-                </FormField>
-              </SpaceBetween>
-            </div>
-          ),
-          isOptional: true,
-        },
-        {
-          title: "Agent configuration",
-          description: "Configure the agent's iteration count and reasoning level.",
-          content: (
-            <div style={{ minHeight: 200 }}>
-              <SpaceBetween size="s">
-                <FormField
-                  label="Iterations"
-                  info={
-                    <Popover
-                      header="Iterations"
-                      content={
-                        <Box>
-                          Determines the number of runs needed to generate the threat catalog.
-                          Increasing the number of runs will result in a more comprehensive and
-                          detailed threat catalog. Use "Auto" to let the agent decide.
-                        </Box>
-                      }
-                    >
-                      <Link variant="info">Info</Link>
-                    </Popover>
-                  }
-                  description="Number of threat cataloging runs."
-                >
-                  <Select
-                    options={[
-                      { label: "Auto", value: 0 },
-                      { label: "1", value: 1 },
-                      { label: "2", value: 2 },
-                      { label: "3", value: 3 },
-                      { label: "5", value: 5 },
-                      { label: "7", value: 7 },
-                      { label: "10", value: 10 },
-                    ]}
-                    selectedOption={iteration}
-                    triggerVariant="option"
-                    onChange={({ detail }) => setIteration(detail.selectedOption)}
-                  />
-                </FormField>
-                <FormField
-                  label="Reasoning boost"
-                  description="Controls the amount of time the model spends thinking before responding."
-                >
-                  <Slider
-                    i18nStrings={I18nProvider}
-                    onChange={({ detail }) => setReasoning(detail.value)}
-                    value={reasoning}
-                    valueFormatter={(value) =>
-                      reasoningLabels.find((item) => item.value === value.toString())?.label || ""
-                    }
-                    ariaDescription={"From None to Max"}
-                    max={maxReasoning}
-                    min={0}
-                    referenceValues={reasoningReferenceValues}
-                    step={1}
-                  />
-                </FormField>
-              </SpaceBetween>
-            </div>
-          ),
-          isOptional: true,
-        },
-        {
-          title: "Provide assumptions",
-          description:
-            "Establish the baseline security context and boundaries that help identify what's in scope for analysis and what potential threats are relevant to consider.",
-          content: (
-            <div style={{ minHeight: 200 }}>
-              <SpaceBetween direction="vertical" size="xs">
-                <Grid gridDefinition={[{ colspan: { default: 8 } }, { colspan: { default: 4 } }]}>
+        }}
+        activeStepIndex={activeStepIndex}
+        submitButtonText="Start threat modeling"
+        isLoadingNextStep={loading}
+        onSubmit={() => {
+          handleStart(
+            title,
+            text,
+            assumptions,
+            applicationType.value,
+            selectedSpaceOption?.value || null
+          );
+        }}
+        steps={[
+          {
+            title: "Title",
+            description: "Provide a meaningful title for the threat model.",
+            content: (
+              <div data-testid="wizard-step-title" style={{ minHeight: 200 }}>
+                <FormField errorText={error ? "Title is required." : null}>
                   <Input
-                    value={newAssumption}
-                    onChange={({ detail }) => setNewAssumption(detail.value)}
-                    placeholder="Type new assumption"
+                    value={title}
+                    onChange={(event) => setTitle(event.detail.value)}
+                    ariaLabel="Threat model title"
                   />
-                  <Button
-                    onClick={handleAddAssumption}
-                    disabled={!newAssumption.trim()}
-                    ariaLabel="Add new assumption"
+                </FormField>
+              </div>
+            ),
+          },
+          {
+            title: "Architecture diagram(s)",
+            description:
+              "Upload one primary architecture diagram (required). You can add up to 2 aiding diagrams (optional) to provide extra views — detailed, security layer, etc. Max 3.75 MB per file.",
+            content: (
+              <div style={{ minHeight: 200 }}>
+                <SpaceBetween size="l">
+                  <FormField
+                    label="Primary architecture diagram"
+                    description="The main diagram. Used as the baseline when creating future versions of this threat model."
                   >
-                    Add
-                  </Button>
-                </Grid>
-                <TokenGroup
-                  items={assumptions.map((item) => ({
-                    label: item,
-                    dismissLabel: `Remove ${item}`,
-                    disabled: false,
-                  }))}
-                  onDismiss={({ detail }) => {
-                    handleRemoveAssumption(detail.itemIndex);
-                  }}
-                />
-              </SpaceBetween>
-            </div>
-          ),
-          isOptional: true,
-        },
-        {
-          title: "Review and launch",
-          content: (
-            <div style={{ minHeight: 250 }}>
-              <SpaceBetween size="xl">
-                {title.length > 0 && (
-                  <SpaceBetween size="xs">
-                    <Header
-                      variant="h3"
-                      actions={
-                        <Button onClick={() => setActiveStepIndex(0)} ariaLabel="Edit title">
-                          Edit
-                        </Button>
+                    <StartComponent
+                      onBase64Change={setPrimaryBase64}
+                      value={primaryValue}
+                      setValue={setPrimaryValue}
+                      error={error}
+                      setError={setError}
+                      maxFiles={1}
+                      buttonText="Choose primary diagram"
+                      constraintText={`PNG or JPG. Max ${MAX_FILE_SIZE_DISPLAY}.`}
+                      requiredErrorText="A primary architecture diagram is required before moving to the next step"
+                    />
+                  </FormField>
+                  <FormField
+                    label={
+                      <span>
+                        Aiding diagrams <i>- optional</i>
+                      </span>
+                    }
+                    description={`Additional views (detailed, security layer, etc.) to aid analysis. Up to ${MAX_AIDING_FILES} files.`}
+                  >
+                    <StartComponent
+                      onBase64Change={setAidingBase64}
+                      value={aidingValue}
+                      setValue={setAidingValue}
+                      error={false}
+                      setError={() => {}}
+                      maxFiles={MAX_AIDING_FILES}
+                      buttonText="Choose aiding diagrams"
+                      constraintText={`Optional. Select up to ${MAX_AIDING_FILES} additional diagrams (PNG/JPG). Max ${MAX_FILE_SIZE_DISPLAY} per file.`}
+                    />
+                  </FormField>
+                </SpaceBetween>
+              </div>
+            ),
+          },
+          {
+            title: "Details",
+            description: "Provide details about your application to help scope the threat model.",
+            content: (
+              <div style={{ minHeight: 200 }}>
+                <SpaceBetween size="s">
+                  <FormField
+                    label="Application type"
+                    info={
+                      <Popover
+                        header="Application type"
+                        content={
+                          <SpaceBetween size="s">
+                            <Box>
+                              <Box variant="h5">Internal</Box>
+                              Accessible only within a private network. Reduced external threat
+                              exposure, but insider threats and misconfigurations remain relevant.
+                            </Box>
+                            <Box>
+                              <Box variant="h5">Hybrid</Box>
+                              Both internal and external-facing components. Public parts get full
+                              rigor, internal parts reflect reduced exposure.
+                            </Box>
+                            <Box>
+                              <Box variant="h5">Public facing</Box>
+                              Internet-facing, accessible by anonymous users. Subject to constant
+                              automated attacks and broad threat actor exposure.
+                            </Box>
+                          </SpaceBetween>
+                        }
+                      >
+                        <Link variant="info">Info</Link>
+                      </Popover>
+                    }
+                  >
+                    <Select
+                      options={[
+                        { label: "Internal", value: "internal" },
+                        { label: "Hybrid", value: "hybrid" },
+                        { label: "Public facing", value: "public_facing" },
+                      ]}
+                      selectedOption={applicationType}
+                      onChange={({ detail }) => setApplicationType(detail.selectedOption)}
+                    />
+                  </FormField>
+                  <FormField
+                    label="Space"
+                    constraintText="Optional — attach a knowledge base to enrich threat modeling context."
+                    info={
+                      <Popover
+                        header="Spaces"
+                        content={
+                          <SpaceBetween size="s">
+                            <Box>
+                              A Space is a knowledge base you manage. Upload architecture docs,
+                              runbooks, or security policies and the agent will query them before
+                              threat modeling to surface relevant context.
+                            </Box>
+                            <Box>
+                              <Box variant="h5">What to upload</Box>
+                              Network diagrams, data classification docs, compliance requirements,
+                              existing security controls, or any reference material specific to your
+                              environment.
+                            </Box>
+                            <Box>
+                              <Box variant="h5">How it works</Box>
+                              Before analyzing your architecture, the agent queries the Space and
+                              injects relevant insights into the threat modeling process.
+                            </Box>
+                          </SpaceBetween>
+                        }
+                      >
+                        <Link variant="info">Info</Link>
+                      </Popover>
+                    }
+                  >
+                    <Select
+                      options={[{ label: "None", value: null }, ...spaces]}
+                      selectedOption={selectedSpaceOption || { label: "None", value: null }}
+                      onChange={({ detail }) =>
+                        setSelectedSpaceOption(
+                          detail.selectedOption.value ? detail.selectedOption : null
+                        )
                       }
-                    >
-                      Step 1: Title
-                    </Header>
+                      placeholder="Select a space (optional)"
+                    />
+                  </FormField>
+                  <FormField
+                    label="Description"
+                    info={
+                      <Popover
+                        header="Description tips"
+                        content={
+                          <SpaceBetween size="s">
+                            <Box>
+                              Use this field to provide context that can't be inferred from the
+                              architecture diagram alone. For example:
+                            </Box>
+                            <Box>
+                              <Box variant="h5">Data sensitivity</Box>
+                              What types of data does the system handle? (PII, financial records,
+                              health data, credentials)
+                            </Box>
+                            <Box>
+                              <Box variant="h5">User base and access</Box>
+                              Who uses the system? Internal employees, external customers,
+                              third-party partners?
+                            </Box>
+                            <Box>
+                              <Box variant="h5">Compliance requirements</Box>
+                              Any regulatory frameworks that apply? (GDPR, HIPAA, PCI-DSS, SOC 2)
+                            </Box>
+                            <Box>
+                              <Box variant="h5">Deployment context</Box>
+                              Cloud provider, on-premises, hybrid? Multi-region? Shared tenancy?
+                            </Box>
+                          </SpaceBetween>
+                        }
+                      >
+                        <Link variant="info">Info</Link>
+                      </Popover>
+                    }
+                  >
+                    <Textarea
+                      onChange={({ detail }) => setText(detail.value)}
+                      value={text}
+                      placeholder="Add your description"
+                    />
+                  </FormField>
+                </SpaceBetween>
+              </div>
+            ),
+            isOptional: true,
+          },
+          {
+            title: "Agent configuration",
+            description: "Configure the agent's iteration count and reasoning level.",
+            content: (
+              <div style={{ minHeight: 200 }}>
+                <SpaceBetween size="s">
+                  <FormField
+                    label="Iterations"
+                    info={
+                      <Popover
+                        header="Iterations"
+                        content={
+                          <Box>
+                            Determines the number of runs needed to generate the threat catalog.
+                            Increasing the number of runs will result in a more comprehensive and
+                            detailed threat catalog. Use "Auto" to let the agent decide.
+                          </Box>
+                        }
+                      >
+                        <Link variant="info">Info</Link>
+                      </Popover>
+                    }
+                    description="Number of threat cataloging runs."
+                  >
+                    <Select
+                      options={[
+                        { label: "Auto", value: 0 },
+                        { label: "1", value: 1 },
+                        { label: "2", value: 2 },
+                        { label: "3", value: 3 },
+                        { label: "5", value: 5 },
+                        { label: "7", value: 7 },
+                        { label: "10", value: 10 },
+                      ]}
+                      selectedOption={iteration}
+                      triggerVariant="option"
+                      onChange={({ detail }) => setIteration(detail.selectedOption)}
+                    />
+                  </FormField>
+                  <FormField
+                    label="Reasoning boost"
+                    description="Controls the amount of time the model spends thinking before responding."
+                  >
+                    <EffortSlider value={reasoning} onChange={setReasoning} />
+                  </FormField>
+                </SpaceBetween>
+              </div>
+            ),
+            isOptional: true,
+          },
+          {
+            title: "Provide assumptions",
+            description:
+              "Establish the baseline security context and boundaries that help identify what's in scope for analysis and what potential threats are relevant to consider.",
+            content: (
+              <div style={{ minHeight: 200 }}>
+                <SpaceBetween direction="vertical" size="xs">
+                  <Grid gridDefinition={[{ colspan: { default: 8 } }, { colspan: { default: 4 } }]}>
                     <Input
-                      onChange={({ detail }) => setTitle(detail.value)}
-                      value={title}
-                      disabled
+                      value={newAssumption}
+                      onChange={({ detail }) => setNewAssumption(detail.value)}
+                      placeholder="Type new assumption"
                     />
-                  </SpaceBetween>
-                )}
-                {combinedFiles[0] && (
-                  <SpaceBetween size="xs">
-                    <Header
-                      variant="h3"
-                      actions={
-                        <Button
-                          onClick={() => setActiveStepIndex(1)}
-                          ariaLabel="Edit architecture diagrams"
-                        >
-                          Edit
-                        </Button>
-                      }
+                    <Button
+                      onClick={handleAddAssumption}
+                      disabled={!newAssumption.trim()}
+                      ariaLabel="Add new assumption"
                     >
-                      Step 2: Architecture diagram(s)
-                    </Header>
-                    <FileTokenGroup
-                      i18nStrings={{
-                        removeFileAriaLabel: (e) => `Remove file ${e + 1}`,
-                        limitShowFewer: "Show fewer files",
-                        limitShowMore: "Show more files",
-                        errorIconAriaLabel: "Error",
-                        warningIconAriaLabel: "Warning",
-                      }}
-                      items={combinedFiles.map((file) => ({ file }))}
-                      readOnly
-                      showFileLastModified
-                      showFileThumbnail
-                      showFileSize
-                    />
-                  </SpaceBetween>
-                )}
-                {(text.length > 0 || applicationType || selectedSpaceOption) && (
-                  <SpaceBetween size="xs">
-                    <Header
-                      variant="h3"
-                      actions={
-                        <Button onClick={() => setActiveStepIndex(2)} ariaLabel="Edit details">
-                          Edit
-                        </Button>
-                      }
-                    >
-                      Step 3: Details
-                    </Header>
-                    {text.length > 0 && (
-                      <Textarea
-                        onChange={({ detail }) => setText(detail.value)}
-                        value={text}
-                        placeholder="Add your description"
+                      Add
+                    </Button>
+                  </Grid>
+                  <TokenGroup
+                    items={assumptions.map((item) => ({
+                      label: item,
+                      dismissLabel: `Remove ${item}`,
+                      disabled: false,
+                    }))}
+                    onDismiss={({ detail }) => {
+                      handleRemoveAssumption(detail.itemIndex);
+                    }}
+                  />
+                </SpaceBetween>
+              </div>
+            ),
+            isOptional: true,
+          },
+          {
+            title: "Review and launch",
+            content: (
+              <div style={{ minHeight: 250 }}>
+                <SpaceBetween size="xl">
+                  {title.length > 0 && (
+                    <SpaceBetween size="xs">
+                      <Header
+                        variant="h3"
+                        actions={
+                          <Button onClick={() => setActiveStepIndex(0)} ariaLabel="Edit title">
+                            Edit
+                          </Button>
+                        }
+                      >
+                        Step 1: Title
+                      </Header>
+                      <Input
+                        onChange={({ detail }) => setTitle(detail.value)}
+                        value={title}
                         disabled
                       />
-                    )}
-                    <FormField label="Application type">
-                      <Input value={applicationType.label} disabled />
-                    </FormField>
-                    {selectedSpaceOption && (
-                      <FormField label="Space">
-                        <Input value={selectedSpaceOption.label} disabled />
+                    </SpaceBetween>
+                  )}
+                  {combinedFiles[0] && (
+                    <SpaceBetween size="xs">
+                      <Header
+                        variant="h3"
+                        actions={
+                          <Button
+                            onClick={() => setActiveStepIndex(1)}
+                            ariaLabel="Edit architecture diagrams"
+                          >
+                            Edit
+                          </Button>
+                        }
+                      >
+                        Step 2: Architecture diagram(s)
+                      </Header>
+                      <FileTokenGroup
+                        i18nStrings={{
+                          removeFileAriaLabel: (e) => `Remove file ${e + 1}`,
+                          limitShowFewer: "Show fewer files",
+                          limitShowMore: "Show more files",
+                          errorIconAriaLabel: "Error",
+                          warningIconAriaLabel: "Warning",
+                        }}
+                        items={combinedFiles.map((file) => ({ file }))}
+                        readOnly
+                        showFileLastModified
+                        showFileThumbnail
+                        showFileSize
+                      />
+                    </SpaceBetween>
+                  )}
+                  {(text.length > 0 || applicationType || selectedSpaceOption) && (
+                    <SpaceBetween size="xs">
+                      <Header
+                        variant="h3"
+                        actions={
+                          <Button onClick={() => setActiveStepIndex(2)} ariaLabel="Edit details">
+                            Edit
+                          </Button>
+                        }
+                      >
+                        Step 3: Details
+                      </Header>
+                      {text.length > 0 && (
+                        <Textarea
+                          onChange={({ detail }) => setText(detail.value)}
+                          value={text}
+                          placeholder="Add your description"
+                          disabled
+                        />
+                      )}
+                      <FormField label="Application type">
+                        <Input value={applicationType.label} disabled />
                       </FormField>
-                    )}
-                  </SpaceBetween>
-                )}
-                {iteration && (
-                  <SpaceBetween size="xs">
-                    <Header
-                      variant="h3"
-                      actions={
-                        <Button onClick={() => setActiveStepIndex(3)} ariaLabel="Edit iterations">
-                          Edit
-                        </Button>
-                      }
-                    >
-                      Step 4: Agent configuration
-                    </Header>
-                    <FormField>
-                      <Select
-                        disabled
-                        options={[
-                          { label: "1", value: "1" },
-                          { label: "2", value: "2" },
-                          { label: "3", value: "3" },
-                          { label: "4", value: "4" },
-                          { label: "5", value: "5" },
-                        ]}
-                        selectedOption={iteration}
-                        triggerVariant="option"
-                        onChange={({ detail }) => setIteration(detail.selectedOption)}
-                      />
-                    </FormField>
-                    <Slider
-                      i18nStrings={I18nProvider}
-                      readOnly={true}
-                      onChange={({ detail }) => setReasoning(detail.value)}
-                      value={reasoning}
-                      valueFormatter={(value) =>
-                        reasoningLabels.find((item) => item.value === value.toString())?.label || ""
-                      }
-                      ariaDescription={"From None to Max"}
-                      max={maxReasoning}
-                      min={0}
-                      referenceValues={reasoningReferenceValues}
-                      step={1}
-                    />
-                  </SpaceBetween>
-                )}
-                {assumptions.length > 0 && (
-                  <SpaceBetween size="xs">
-                    <Header
-                      variant="h3"
-                      actions={
-                        <Button onClick={() => setActiveStepIndex(4)} ariaLabel="Edit assumptions">
-                          Edit
-                        </Button>
-                      }
-                    >
-                      Step 5: Assumptions
-                    </Header>
-                    <FormField>
-                      <TokenGroup items={convertArrayToObjects(assumptions)} readOnly />
-                    </FormField>
-                  </SpaceBetween>
-                )}
-              </SpaceBetween>
-            </div>
-          ),
-        },
-      ]}
-    />
+                      {selectedSpaceOption && (
+                        <FormField label="Space">
+                          <Input value={selectedSpaceOption.label} disabled />
+                        </FormField>
+                      )}
+                    </SpaceBetween>
+                  )}
+                  {iteration && (
+                    <SpaceBetween size="xs">
+                      <Header
+                        variant="h3"
+                        actions={
+                          <Button onClick={() => setActiveStepIndex(3)} ariaLabel="Edit iterations">
+                            Edit
+                          </Button>
+                        }
+                      >
+                        Step 4: Agent configuration
+                      </Header>
+                      <FormField>
+                        <Select
+                          disabled
+                          options={[
+                            { label: "1", value: "1" },
+                            { label: "2", value: "2" },
+                            { label: "3", value: "3" },
+                            { label: "4", value: "4" },
+                            { label: "5", value: "5" },
+                          ]}
+                          selectedOption={iteration}
+                          triggerVariant="option"
+                          onChange={({ detail }) => setIteration(detail.selectedOption)}
+                        />
+                      </FormField>
+                      <EffortSlider value={reasoning} readOnly={true} />
+                    </SpaceBetween>
+                  )}
+                  {assumptions.length > 0 && (
+                    <SpaceBetween size="xs">
+                      <Header
+                        variant="h3"
+                        actions={
+                          <Button
+                            onClick={() => setActiveStepIndex(4)}
+                            ariaLabel="Edit assumptions"
+                          >
+                            Edit
+                          </Button>
+                        }
+                      >
+                        Step 5: Assumptions
+                      </Header>
+                      <FormField>
+                        <TokenGroup items={convertArrayToObjects(assumptions)} readOnly />
+                      </FormField>
+                    </SpaceBetween>
+                  )}
+                </SpaceBetween>
+              </div>
+            ),
+          },
+        ]}
+      />
     </div>
   );
 };

--- a/src/components/ThreatModeling/ThreatModeling.jsx
+++ b/src/components/ThreatModeling/ThreatModeling.jsx
@@ -10,7 +10,7 @@ import "./ThreatModeling.css";
 
 export default function ThreatModeling() {
   const [iteration, setIteration] = useState({ label: "Auto", value: 0 });
-  const [reasoning, setReasoning] = useState("0");
+  const [reasoning, setReasoning] = useState("1");
   const [base64Content, setBase64Content] = useState([]);
   const [id, setId] = useState(null);
   const [visible, setVisible] = useState(false);

--- a/src/components/ThreatModeling/VersionModal.jsx
+++ b/src/components/ThreatModeling/VersionModal.jsx
@@ -11,19 +11,8 @@ import {
   TokenGroup,
 } from "@cloudscape-design/components";
 import Alert from "@cloudscape-design/components/alert";
-import { I18nProvider } from "@cloudscape-design/components/i18n";
-import Slider from "@cloudscape-design/components/slider";
+import EffortSlider from "../EffortSlider";
 import StartComponent from "./StartComponent";
-
-const REASONING_LABELS = [
-  { value: "0", label: "None" },
-  { value: "1", label: "Low" },
-  { value: "2", label: "Medium" },
-  { value: "3", label: "High" },
-  { value: "4", label: "Max" },
-];
-const REASONING_REFERENCE_VALUES = [1, 2, 3];
-const MAX_REASONING = 4;
 
 export const VersionModalComponent = ({
   visible,
@@ -35,7 +24,7 @@ export const VersionModalComponent = ({
   onVersion,
 }) => {
   const [title, setTitle] = useState(currentTitle);
-  const [reasoning, setReasoning] = useState("0");
+  const [reasoning, setReasoning] = useState("1");
   const [description, setDescription] = useState(currentDescription);
   const [assumptions, setAssumptions] = useState(
     currentAssumptions.map((a, i) => ({ label: a, dismissLabel: `Remove ${a}` }))
@@ -153,7 +142,10 @@ export const VersionModalComponent = ({
           />
         </FormField>
 
-        <FormField label="Architecture diagram" description="Upload the new architecture diagram for version comparison.">
+        <FormField
+          label="Architecture diagram"
+          description="Upload the new architecture diagram for version comparison."
+        >
           <StartComponent
             onBase64Change={handleBase64Change}
             value={fileValue}
@@ -214,19 +206,7 @@ export const VersionModalComponent = ({
           label="Reasoning boost"
           description="Controls the amount of thinking time for the version analysis."
         >
-          <Slider
-            i18nStrings={I18nProvider}
-            onChange={({ detail }) => setReasoning(detail.value)}
-            value={reasoning}
-            valueFormatter={(value) =>
-              REASONING_LABELS.find((item) => item.value === value.toString())?.label || ""
-            }
-            ariaDescription="From None to Max"
-            max={MAX_REASONING}
-            min={0}
-            referenceValues={REASONING_REFERENCE_VALUES}
-            step={1}
-          />
+          <EffortSlider value={reasoning} onChange={setReasoning} />
         </FormField>
 
         <FormField label="Mirror options">

--- a/src/components/ThreatModeling/threatmodel/ThreatModelHeader.jsx
+++ b/src/components/ThreatModeling/threatmodel/ThreatModelHeader.jsx
@@ -44,52 +44,56 @@ const ThreatModelHeader = React.memo(
   }) => {
     return (
       <div data-testid="threat-model-header">
-      <SpaceBetween size="xxl">
-        <BreadcrumbGroup items={breadcrumbs} ariaLabel="Breadcrumbs" onClick={onBreadcrumbClick} />
-        <Header
-          variant="h1"
-          actions={
-            <ThreatModelActions
-              showResults={showResults}
-              showProcessing={showProcessing}
-              isReadOnly={isReadOnly}
-              isOwner={isOwner}
-              onActionClick={onActionClick}
-              tmStatus={tmStatus}
-              showDashboard={showDashboard}
-              onToggleDashboard={onToggleDashboard}
-            />
-          }
-          description={
-            parentId ? (
-              <span>
-                Derived from:{" "}
-                <Link variant="secondary" href={`/${parentId}`}>
-                  {parentTitle || parentId}
-                </Link>
-                {onCompare && (
-                  <>
-                    {" · "}
-                    <Link
-                      variant="secondary"
-                      onFollow={(e) => {
-                        e.preventDefault();
-                        onCompare();
-                      }}
-                    >
-                      Compare
-                    </Link>
-                  </>
-                )}
-              </span>
-            ) : undefined
-          }
-        >
-          <SpaceBetween direction="horizontal" size="xs">
-            <div>{title}</div>
-          </SpaceBetween>
-        </Header>
-      </SpaceBetween>
+        <SpaceBetween size="xxl">
+          <BreadcrumbGroup
+            items={breadcrumbs}
+            ariaLabel="Breadcrumbs"
+            onClick={onBreadcrumbClick}
+          />
+          <Header
+            variant="h1"
+            actions={
+              <ThreatModelActions
+                showResults={showResults}
+                showProcessing={showProcessing}
+                isReadOnly={isReadOnly}
+                isOwner={isOwner}
+                onActionClick={onActionClick}
+                tmStatus={tmStatus}
+                showDashboard={showDashboard}
+                onToggleDashboard={onToggleDashboard}
+              />
+            }
+            description={
+              parentId ? (
+                <span>
+                  Derived from:{" "}
+                  <Link variant="secondary" href={`/${parentId}`}>
+                    {parentTitle || parentId}
+                  </Link>
+                  {onCompare && (
+                    <>
+                      {" · "}
+                      <Link
+                        variant="secondary"
+                        onFollow={(e) => {
+                          e.preventDefault();
+                          onCompare();
+                        }}
+                      >
+                        Compare
+                      </Link>
+                    </>
+                  )}
+                </span>
+              ) : undefined
+            }
+          >
+            <SpaceBetween direction="horizontal" size="xs">
+              <div>{title}</div>
+            </SpaceBetween>
+          </Header>
+        </SpaceBetween>
       </div>
     );
   }

--- a/src/e2e/amplifyAuthMock.js
+++ b/src/e2e/amplifyAuthMock.js
@@ -77,8 +77,15 @@ export const confirmResetPassword = () => Promise.resolve();
 // skip Amplify.configure(), but the ESM import graph still resolves them.
 export const CognitoAWSCredentialsAndIdentityIdProvider = class {};
 export const DefaultIdentityIdStore = class {};
-export const cognitoCredentialsProvider = { clearCredentials: () => {}, getCredentialsAndIdentityId: () => Promise.resolve(null) };
-export const cognitoUserPoolsTokenProvider = { setAuthConfig: () => {}, setKeyValueStorage: () => {}, getTokens: () => Promise.resolve(null) };
+export const cognitoCredentialsProvider = {
+  clearCredentials: () => {},
+  getCredentialsAndIdentityId: () => Promise.resolve(null),
+};
+export const cognitoUserPoolsTokenProvider = {
+  setAuthConfig: () => {},
+  setKeyValueStorage: () => {},
+  getTokens: () => Promise.resolve(null),
+};
 
 export default {
   fetchAuthSession,


### PR DESCRIPTION
## Models and providers
- Claude 5 family (Opus 5 main, Sonnet 5 for Sentry/struct, Haiku 4.5 for summaries) and
  the GPT-5.6 fleet (Sol/Terra/Luna).
- **New provider `bedrock-mantle`**: the same GPT models via the Bedrock OpenAI-compatible
  endpoint — no OpenAI API key, SigV4 bearer tokens from the runtime role, inference pinned
  to a US region via `mantle_region`.
- `temperature` dropped everywhere (rejected by GPT-5 and Claude 4.6+), and GPT calls now
  send a hashed `safety_identifier` so traffic is attributed per user.

## Reasoning ladder is now 1–4, topping out at `xhigh`
Level 0 is gone: every current model is a reasoning model, and on Opus 5 thinking can't be
disabled above effort `high` — level 0 billed for thinking and threw the output away. Level 4
maps to `xhigh` rather than `max` (`max` costs far more for marginal gain; still opt-in per
stage). Legacy `0` from older clients is clamped up rather than rejected. Adds a shared
`EffortSlider` used by Sentry and the wizard.

## Web search: AgentCore connector as an alternative to Tavily
`web_search_provider` is now `none` | `tavily` | `agentcore`. The AgentCore path is
search-only, so the web-fetch tool and its prompt guidance are absent when it's selected. Its
gateway lives in `web_search_region`, which may differ from the deployment region.