### PR TITLE
fix(mcp): correct threat model status poll timeout

### DIFF
--- a/mcp-server/threat_designer_mcp/server.py
+++ b/mcp-server/threat_designer_mcp/server.py
@@ -228,7 +228,11 @@ async def create_threat_model(ctx: Context, payload: StartThreatModeling) -> str
 async def poll_threat_model_status(ctx: Context, model_id: str) -> str:
     """Poll the status of a threat model until completion or failure. It can take between 10 - 15minutes."""
     # Define constants
-    MAX_POLLING_TIME = 20
+    # ~20 minutes of wall-clock time, matching the documented "10 - 15 minutes"
+    # modeling duration. time.time() returns epoch seconds. Values must be in
+    # seconds; a value of 20 here caused the poll to give up after only 2
+    # iterations (20 s / 10 s interval) and always return "still processing".
+    MAX_POLLING_TIME = 1200  # 20 minutes, in seconds
     POLLING_INTERVAL = 10  # 10 seconds
     app_context = ctx.request_context.lifespan_context
 


### PR DESCRIPTION
## Problem

In the MCP server, `poll_threat_model_status()` sets `MAX_POLLING_TIME = 20` while `POLLING_INTERVAL = 10`. `time.time()` returns epoch seconds, so the loop's bail condition (`current_time - start_time > MAX_POLLING_TIME`) compares against *seconds* of wall-clock time. The poll therefore gives up after only ~20 seconds (about 2 iterations) and always returns `{"status": "PROCESSING", "message": "Threat modeling still processing. Try again later."}`.

Modeling jobs take 10–15 minutes (as the function docstring and the MCP README state), so callers never see the `COMPLETE`/`FAILED` terminal status through this tool — they get "still processing" regardless. This defeats the purpose of `poll_threat_model_status`, which is specifically meant to wait for completion.

## Fix

Set `MAX_POLLING_TIME = 1200` (~20 minutes) so the status is polled for the full expected duration and the terminal result is returned once the job finishes; the timeout only takes effect if a job genuinely runs longer than expected. Behavior of the error/recovery paths is unchanged. Verified with `python -m py_compile`.