### PR TITLE
fix(collab): gate replay on the edit lock and settle version ownership

### DIFF
--- a/backend/app/openapi.yml
+++ b/backend/app/openapi.yml
@@ -623,6 +623,11 @@ paths:
         requires EDIT access to that model. With `version` it forks the model named by
         `id` into a new one, which requires at least READ_ONLY access to it. `replay` and
         `version` are mutually exclusive.
+
+        Replay is refused with 409 while another user holds the edit lock, since it
+        rewrites the model and would discard their unsaved changes. A version belongs to
+        the owner of the model it forks; a collaborator who creates one is granted EDIT
+        access to it so they can reach what they made.
       tags:
         - Security
       requestBody:
@@ -651,6 +656,8 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+        "409":
+          $ref: "#/components/responses/409"
         "500":
           $ref: "#/components/responses/500"
       x-amazon-apigateway-integration:

--- a/backend/app/routes/threat_designer_route.py
+++ b/backend/app/routes/threat_designer_route.py
@@ -526,11 +526,9 @@ def _get_lock_status(id):
 
         require_access(id, user_id, required_level="READ_ONLY")
 
-        status = get_lock_status(id)
-
-        # lock_token is the holder's write credential, checked by update_results.
-        # Only acquire_lock returns it, to the user it just granted the lock to.
-        return {k: v for k, v in status.items() if k != "lock_token"}
+        # get_lock_status no longer carries lock_token, so this cannot leak the holder's
+        # write credential. lock_service.lock_token_matches is the only way to test it.
+        return get_lock_status(id)
     except Exception as e:
         LOG.exception(e)
         raise

--- a/backend/app/services/collaboration_service.py
+++ b/backend/app/services/collaboration_service.py
@@ -281,7 +281,7 @@ def get_collaborators(threat_model_id: str, requester: str) -> List[Dict]:
 
         return {"collaborators": collaborators}
 
-    except UnauthorizedError:
+    except (UnauthorizedError, NotFoundError):
         raise
     except Exception as e:
         LOG.error(f"Error getting collaborators: {e}")
@@ -355,7 +355,7 @@ def remove_collaborator(
             "removed_user": collaborator_user_id,
         }
 
-    except UnauthorizedError:
+    except (UnauthorizedError, NotFoundError):
         raise
     except Exception as e:
         LOG.error(f"Error removing collaborator: {e}")

--- a/backend/app/services/lock_service.py
+++ b/backend/app/services/lock_service.py
@@ -345,7 +345,6 @@ def get_lock_status(threat_model_id: str) -> Dict[str, Any]:
             "locked": True,
             "user_id": user_id,
             "username": username,
-            "lock_token": lock.get("lock_token"),
             "since": lock.get("acquired_at"),
             "lock_timestamp": int(lock_timestamp),
             "expires_at": ttl,
@@ -355,6 +354,45 @@ def get_lock_status(threat_model_id: str) -> Dict[str, Any]:
     except Exception as e:
         LOG.error(f"Error getting lock status: {e}")
         raise InternalError(f"Failed to get lock status: {str(e)}")
+
+
+@tracer.capture_method
+def lock_token_matches(threat_model_id: str, lock_token: str) -> bool:
+    """
+    Check whether a lock token is the one currently held on a threat model.
+
+    Deliberately separate from get_lock_status: the token is a write credential, and
+    get_lock_status feeds an HTTP response. Keeping the token out of that dict means a
+    handler cannot leak it by returning the status verbatim. update_results is the only
+    caller that needs to compare it.
+
+    Args:
+        threat_model_id: The threat model ID
+        lock_token: The token to compare against the stored lock
+
+    Returns:
+        True if an active lock exists and its token matches, False otherwise. A stale
+        lock counts as absent, matching get_lock_status, so a token cannot outlive the
+        lock it was issued for and acquire_lock may already have reassigned.
+    """
+    lock_table = dynamodb.Table(LOCK_TABLE)
+
+    try:
+        response = lock_table.get_item(Key={"threat_model_id": threat_model_id})
+
+        if "Item" not in response:
+            return False
+
+        lock = response["Item"]
+
+        if int(time.time()) - int(lock.get("lock_timestamp", 0)) > STALE_LOCK_THRESHOLD:
+            return False
+
+        return lock.get("lock_token") == lock_token
+
+    except Exception as e:
+        LOG.error(f"Error comparing lock token: {e}")
+        raise InternalError(f"Failed to compare lock token: {str(e)}")
 
 
 @tracer.capture_method
@@ -407,7 +445,7 @@ def force_release_lock(threat_model_id: str, owner: str) -> Dict[str, Any]:
             "previous_holder": previous_holder,
         }
 
-    except UnauthorizedError:
+    except (UnauthorizedError, NotFoundError):
         raise
     except Exception as e:
         LOG.error(f"Error force releasing lock: {e}")

--- a/backend/app/services/threat_designer_service.py
+++ b/backend/app/services/threat_designer_service.py
@@ -301,12 +301,41 @@ def invoke_lambda(owner, payload):
     # mirror_sharing copies the parent's collaborator roster onto the new version. It
     # needs no further check: get_collaborators already exposes that roster to anyone
     # with access, so require_access below is the whole boundary.
+    target_access = None
     if (is_replay or is_version) and owner != "MCP":
         from utils.authorization import require_access
 
-        require_access(
+        target_access = require_access(
             target_id, owner, required_level="EDIT" if is_replay else "READ_ONLY"
         )
+
+    # Replay rewrites the threat model wholesale. Every other EDIT-level write goes
+    # through the edit lock, so refuse to run over another user's in-flight edits. The
+    # caller does not have to hold the lock themselves: replay is not an edit-mode
+    # action in the UI, so requiring one would mean acquiring a lock just to re-run.
+    #
+    # This is a pre-check, not a mutual exclusion: the lock can still be taken in the
+    # window between here and the agent's finalize, which would lose that user's save.
+    # Closing that needs the replay to hold the lock for the whole run, which is a
+    # bigger change to how locks are modelled. MCP is included because stomping an
+    # editor's work is not an authorization question and MCP cannot hold a lock.
+    if is_replay:
+        from services.lock_service import get_lock_status
+
+        lock_status = get_lock_status(target_id)
+        if lock_status.get("locked") and lock_status.get("user_id") != owner:
+            holder = lock_status.get("username") or "Another user"
+            raise ConflictError(
+                {
+                    "message": (
+                        f"{holder} is editing this threat model. Replaying now would "
+                        "discard their unsaved changes."
+                    ),
+                    "held_by": lock_status.get("user_id"),
+                    "username": lock_status.get("username"),
+                    "since": lock_status.get("since"),
+                }
+            )
 
     if is_replay:
         id = target_id
@@ -330,24 +359,31 @@ def invoke_lambda(owner, payload):
         # Step 1: Reset any cancelled flag and set state to START
         current_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
-        # A replayed job already belongs to someone. On the status row `owner` is the
-        # threat model's owner, which delete_tm authorizes its stop-execution step
-        # against, while execution_owner is whoever started this particular run.
-        # Overwriting owner with the caller would stop the real owner from cancelling a
-        # run on their own model, and delete_tm swallows that failure and deletes the
-        # model anyway, leaving the run writing back to a deleted job_id.
-        replay_item = None
-        state_owner = owner
-        if is_replay:
+        # Replay needs the target's content for the backup, and both replay and version
+        # need its owner. This repeats the read require_access already did; threading the
+        # item out of check_access would remove it.
+        target_item = None
+        if is_replay or is_version:
             agent_table = dynamodb.Table(AGENT_TABLE)
-            replay_item = agent_table.get_item(Key={"job_id": id}).get("Item")
-            if replay_item:
-                state_owner = replay_item.get("owner", owner)
+            target_item = agent_table.get_item(Key={"job_id": target_id}).get("Item")
+
+        # A replay keeps the job it re-runs, and a version belongs to the owner of the
+        # model it forks, because the agent's finalize reads owner off the parent.
+        # Creating either under the caller would flip ownership partway through the run.
+        #
+        # On the status row `owner` is the threat model's owner, which delete_tm
+        # authorizes its stop-execution step against, while execution_owner is whoever
+        # started this run. Overwriting owner with the caller would stop the real owner
+        # from cancelling a run on their own model, and delete_tm swallows that failure
+        # and deletes the model anyway, leaving the run writing to a deleted job_id.
+        # `or` rather than a get() default: writers strip None values, so a record whose
+        # owner was ever None has the key present-but-empty in some deployments.
+        model_owner = (target_item.get("owner") or owner) if target_item else owner
 
         state_item = {
             "id": id,
             "state": "START",
-            "owner": state_owner,
+            "owner": model_owner,
             "session_id": session_id,
             "execution_owner": owner,
             "updated_at": current_time,
@@ -360,15 +396,29 @@ def invoke_lambda(owner, payload):
 
         # Step 2: If this is a replay, store backup in the dedicated backup table
         if is_replay:
-            if replay_item:
-                backup_table.put_item(Item=copy.deepcopy(replay_item))
-                LOG.info(f"Backup stored in backup table for job_id: {id}")
+            if target_item:
+                _store_replay_backup(id, target_item)
             else:
                 LOG.warning(f"Item not found for backup during replay: {id}")
 
         # Step 2b: If version with mirror_sharing, copy sharing records from parent
         if is_version and mirror_sharing and previous_job_id:
-            _copy_sharing_records(previous_job_id, id)
+            _copy_sharing_records(previous_job_id, id, skip_user_id=model_owner)
+
+        # A collaborator who versions someone else's model does not own the fork, so
+        # grant them the access they need to reach what they just created. Skipped when
+        # they are the owner, since a sharing record naming the owner is rejected
+        # everywhere else and ownership already covers it.
+        #
+        # The grant mirrors what they hold on the parent. Versioning only requires
+        # READ_ONLY, so granting a fixed EDIT would let a read-only collaborator write to
+        # a model in the owner's catalog. It runs after the roster copy so that it wins
+        # over a mirrored record for the same user.
+        if is_version and owner != "MCP" and owner != model_owner:
+            granted_level = (target_access or {}).get("access_level") or "READ_ONLY"
+            if granted_level == "OWNER":
+                granted_level = "EDIT"
+            _grant_creator_access(id, model_owner, owner, granted_level)
 
         # Step 3: Invoke the agent
         agent_input = {
@@ -404,7 +454,7 @@ def invoke_lambda(owner, payload):
             "job_id": id,
             "s3_location": s3_location,
             "s3_locations": s3_locations,
-            "owner": owner,
+            "owner": model_owner,
             "title": title,
             "retry": reasoning,
         }
@@ -414,9 +464,8 @@ def invoke_lambda(owner, payload):
             agent_state["parent_id"] = previous_job_id
 
         if not is_replay:
-            # For version, set is_shared if sharing was mirrored
-            if is_version and mirror_sharing:
-                agent_state["is_shared"] = True
+            # No is_shared here: create_dynamodb_item writes a fixed field list that
+            # drops it, and nothing in the codebase reads the flag anyway.
             create_dynamodb_item(agent_state, AGENT_TABLE)
 
         return {"id": id}
@@ -443,8 +492,64 @@ def invoke_lambda(owner, payload):
         raise InternalError(e)
 
 
-def _copy_sharing_records(source_job_id, target_job_id):
-    """Copy sharing records from one threat model to another."""
+def _store_replay_backup(job_id, item):
+    """
+    Keep a pre-replay copy of a threat model so restore() can undo the replay.
+
+    The write is unconditional, which means the slot always holds the state from just
+    before the most recent replay. That is what both consumers expect: the UI offers
+    "Restore previous version", and delete_session auto-restores when a user stops a
+    run. Preserving older replays as well would need a backup key per replay, and the
+    table is hash-only on job_id (infra/dynamodb.tf), so adding a sort key would replace
+    it and destroy existing backups on apply.
+
+    Args:
+        job_id: The threat model being replayed.
+        item: Its current agent-table record, copied verbatim.
+    """
+    backup_table.put_item(Item=copy.deepcopy(item))
+    LOG.info(f"Backup stored in backup table for job_id: {job_id}")
+
+
+def _grant_creator_access(job_id, model_owner, creator, access_level):
+    """
+    Give the creator of a version access to it when they are not its owner.
+
+    A version belongs to the owner of the model it forks, so a collaborator who creates
+    one would otherwise have no way to reach it.
+
+    Args:
+        job_id: The new version.
+        model_owner: Who owns it, i.e. the parent's owner.
+        creator: The caller who asked for the version.
+        access_level: What the creator holds on the parent, mirrored onto the fork so
+            versioning cannot widen their access.
+    """
+    sharing_table = dynamodb.Table(SHARING_TABLE)
+    sharing_table.put_item(
+        Item={
+            "threat_model_id": job_id,
+            "user_id": creator,
+            "access_level": access_level,
+            "shared_by": model_owner,
+            "shared_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "owner": model_owner,
+        }
+    )
+    LOG.info(f"Granted creator {creator} {access_level} access on version {job_id}")
+
+
+def _copy_sharing_records(source_job_id, target_job_id, skip_user_id=None):
+    """
+    Copy sharing records from one threat model to another.
+
+    Args:
+        source_job_id: The threat model whose roster is copied.
+        target_job_id: The threat model receiving the roster.
+        skip_user_id: A user to leave out, used to keep the target's own owner off its
+            roster. A record naming the owner is rejected everywhere else, and it would
+            make the model show up as both owned and shared.
+    """
     try:
         sharing_table = dynamodb.Table(SHARING_TABLE)
         current_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
@@ -463,6 +568,9 @@ def _copy_sharing_records(source_job_id, target_job_id):
                 break
             query_params["ExclusiveStartKey"] = last_key
 
+        if skip_user_id:
+            items = [item for item in items if item.get("user_id") != skip_user_id]
+
         with sharing_table.batch_writer() as batch:
             for item in items:
                 new_item = copy.deepcopy(item)
@@ -474,7 +582,12 @@ def _copy_sharing_records(source_job_id, target_job_id):
             f"Copied {len(items)} sharing records from {source_job_id} to {target_job_id}"
         )
     except Exception as e:
+        # Raise rather than log and continue. The caller asked for the roster to be
+        # mirrored; reporting the version as created with an empty roster is a silent
+        # lie, and it leaves the model inconsistent with what the user was told. This
+        # runs before the agent is invoked, so failing here costs nothing but the retry.
         LOG.error(f"Failed to copy sharing records: {e}")
+        raise
 
 
 def _delete_sharing_records(job_id):
@@ -628,7 +741,7 @@ def update_results(job_id, payload, owner, lock_token=None):
         # For non-MCP users, check access and verify lock
         if owner != "MCP":
             from utils.authorization import require_access
-            from services.lock_service import get_lock_status
+            from services.lock_service import get_lock_status, lock_token_matches
 
             # Check if user has edit access (will raise UnauthorizedError if not)
             require_access(job_id, owner, required_level="EDIT")
@@ -647,7 +760,7 @@ def update_results(job_id, payload, owner, lock_token=None):
                 raise UnauthorizedError("Lock is held by another user")
 
             # Validate lock token if provided
-            if lock_token and lock_status.get("lock_token") != lock_token:
+            if lock_token and not lock_token_matches(job_id, lock_token):
                 LOG.warning(f"Invalid lock token for threat model {job_id}")
                 raise UnauthorizedError("Invalid lock token")
 
@@ -1098,6 +1211,11 @@ def fetch_shared_paginated(user_id: str, limit: int, cursor: str = None) -> dict
             tm_id = sharing_record["threat_model_id"]
             tm = threat_models.get(tm_id)
             if tm is None:
+                continue
+            # A sharing record naming the model's own owner is rejected on write now, but
+            # records predating that rule would surface the user's own model here as
+            # read-only, alongside the real entry under /owned.
+            if tm.get("owner") == user_id:
                 continue
             tm["is_owner"] = False
             tm["access_level"] = sharing_record["access_level"]

--- a/src/components/ThreatModeling/ThreatModeling.jsx
+++ b/src/components/ThreatModeling/ThreatModeling.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { SubmissionComponent } from "./SubmissionForm";
 import { Modal } from "@cloudscape-design/components";
+import Alert from "@cloudscape-design/components/alert";
 import { uploadFile } from "./docs";
 import { useNavigate } from "react-router-dom";
 import { startThreatModeling, generateUrl } from "../../services/ThreatDesigner/stats";
@@ -16,6 +17,7 @@ export default function ThreatModeling() {
   const [visible, setVisible] = useState(false);
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
 
   const handleBase64Change = useCallback((base64) => {
     setBase64Content(base64);
@@ -69,6 +71,11 @@ export default function ThreatModeling() {
     } catch (error) {
       console.error("Error starting threat modeling:", error);
       setLoading(false);
+      // The endpoint returns real 4xx responses, so surface them. Staying silent here
+      // just stops the spinner and leaves the user with no idea why nothing happened.
+      setSubmitError(
+        error.response?.data?.message || "The threat model could not be started. Please try again."
+      );
     }
   };
 
@@ -98,11 +105,24 @@ export default function ThreatModeling() {
         </div>
       </div>
       <Modal
-        onDismiss={() => setVisible(false)}
+        onDismiss={() => {
+          setVisible(false);
+          setSubmitError(null);
+        }}
         visible={visible}
         size="large"
         header={"Threat model"}
       >
+        {submitError && (
+          <Alert
+            type="error"
+            header="Could not start threat modeling"
+            dismissible
+            onDismiss={() => setSubmitError(null)}
+          >
+            {submitError}
+          </Alert>
+        )}
         <SubmissionComponent
           onBase64Change={handleBase64Change}
           iteration={iteration}

--- a/src/components/ThreatModeling/hooks/useAlert.jsx
+++ b/src/components/ThreatModeling/hooks/useAlert.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 const ALERT_MESSAGES = {
   Info: {
@@ -28,6 +28,10 @@ const ALERT_MESSAGES = {
     title: "Threat model is locked",
     msg: "This threat model is currently being edited by another user.",
   },
+  ReplayLockConflict: {
+    title: "Replay cancelled - threat model is locked",
+    msg: "Another user is editing this threat model. Replaying it now would discard their unsaved changes.",
+  },
   Conflict: {
     title: "Conflict detected",
     msg: "The threat model has been modified by another user since you last loaded it.",
@@ -47,7 +51,9 @@ export const useAlert = () => {
     data: null,
   });
 
-  const showAlert = (state, loading = false, data = null) => {
+  // Memoized because callers list these in useCallback dependency arrays; a fresh
+  // identity each render would defeat those and re-render memoized children.
+  const showAlert = useCallback((state, loading = false, data = null) => {
     setAlert((prev) => ({
       ...prev,
       visible: true,
@@ -55,23 +61,23 @@ export const useAlert = () => {
       loading,
       data,
     }));
-  };
+  }, []);
 
-  const hideAlert = () => {
+  const hideAlert = useCallback(() => {
     setAlert({
       state: "Info",
       visible: false,
       loading: false,
       data: null,
     });
-  };
+  }, []);
 
-  const setLoading = (loading) => {
+  const setLoading = useCallback((loading) => {
     setAlert((prev) => ({
       ...prev,
       loading,
     }));
-  };
+  }, []);
 
   return {
     alert,

--- a/src/components/ThreatModeling/hooks/useThreatModelActions.js
+++ b/src/components/ThreatModeling/hooks/useThreatModelActions.js
@@ -141,12 +141,34 @@ export const useThreatModelActions = ({
 
         setTrigger(Math.floor(Math.random() * 100) + 1);
       } catch (error) {
-        console.error("Error starting threat modeling:", error);
+        // The backend refuses a replay while another user holds the edit lock, since it
+        // rewrites the threat model and would discard their unsaved changes.
+        if (error.response?.status === 409) {
+          console.warn("Replay refused, threat model is locked:", error.response.data);
+          showAlert("ReplayLockConflict");
+        } else {
+          console.error("Error starting threat modeling:", error);
+        }
+        // Undo the optimistic switch into the processing view. setTrigger refetches,
+        // which is what repopulates previousResponse (the finally block below clears it,
+        // and checkChanges silently stops tracking unsaved edits while it is null) and
+        // what restores Sentry visibility after the setisVisible(false) above.
+        setProcessing(false);
+        setResults(true);
+        setTrigger(Math.floor(Math.random() * 100) + 1);
       } finally {
         previousResponse.current = null;
       }
     },
-    [setisVisible, setProcessing, setResults, threatModelId, setTrigger, previousResponse]
+    [
+      setisVisible,
+      setProcessing,
+      setResults,
+      threatModelId,
+      setTrigger,
+      previousResponse,
+      showAlert,
+    ]
   );
 
   /**

--- a/test/app/routes/test_threat_designer_route.py
+++ b/test/app/routes/test_threat_designer_route.py
@@ -255,13 +255,10 @@ class TestGetEndpoints:
     def test_get_lock_status_returns_lock_status(
         self, mock_router, mock_get_lock_status, mock_require_access
     ):
-        """Test _get_lock_status returns lock status without the holder's token."""
+        """Test _get_lock_status returns lock status."""
         mock_router.current_event.request_context.authorizer = {"user_id": "user-123"}
-        mock_get_lock_status.return_value = {
-            "locked": True,
-            "user_id": "user-456",
-            "lock_token": "token-456",
-        }
+        # get_lock_status does not carry lock_token; see its own test for that
+        mock_get_lock_status.return_value = {"locked": True, "user_id": "user-456"}
 
         from routes.threat_designer_route import _get_lock_status
 
@@ -269,8 +266,6 @@ class TestGetEndpoints:
 
         assert result["locked"] is True
         assert result["user_id"] == "user-456"
-        # The token is the holder's write credential and must not leak to other users
-        assert "lock_token" not in result
         mock_require_access.assert_called_once_with(
             "test-job-123", "user-123", required_level="READ_ONLY"
         )

--- a/test/app/services/test_lock_service.py
+++ b/test/app/services/test_lock_service.py
@@ -31,6 +31,7 @@ from services.lock_service import (
     refresh_lock,
     release_lock,
     get_lock_status,
+    lock_token_matches,
     force_release_lock,
     get_username_from_cognito,
     LOCK_EXPIRATION_SECONDS,
@@ -793,11 +794,66 @@ class TestGetLockStatus:
         assert result["locked"] is True
         assert result["user_id"] == user_id
         assert result["username"] == "testuser"
-        assert result["lock_token"] == "token-123"
         assert result["since"] == "2024-01-01T00:00:00Z"
         assert result["lock_timestamp"] == lock_timestamp
         assert isinstance(result["expires_at"], int)
         assert "Locked by testuser" in result["message"]
+        # The token is the holder's write credential and this dict is returned straight
+        # to any user with read access. lock_token_matches is how it gets compared.
+        assert "lock_token" not in result
+
+    @patch.dict(os.environ, {"LOCKS_TABLE": "test-locks-table"})
+    @patch("services.lock_service.dynamodb")
+    def test_lock_token_matches_the_held_token(self, mock_dynamodb):
+        """The token comparison update_results needs, without exposing the token."""
+        # Arrange
+        mock_lock_table = Mock()
+        mock_dynamodb.Table.return_value = mock_lock_table
+        mock_lock_table.get_item.return_value = {
+            "Item": {
+                "threat_model_id": "test-job-123",
+                "lock_token": "token-123",
+                "lock_timestamp": Decimal(str(int(time.time()))),
+            }
+        }
+
+        # Act & Assert
+        assert lock_token_matches("test-job-123", "token-123") is True
+        assert lock_token_matches("test-job-123", "someone-elses-token") is False
+
+    @patch.dict(os.environ, {"LOCKS_TABLE": "test-locks-table"})
+    @patch("services.lock_service.dynamodb")
+    def test_lock_token_does_not_match_when_no_lock(self, mock_dynamodb):
+        """No lock means no token can match, rather than an error."""
+        # Arrange
+        mock_lock_table = Mock()
+        mock_dynamodb.Table.return_value = mock_lock_table
+        mock_lock_table.get_item.return_value = {}
+
+        # Act & Assert
+        assert lock_token_matches("test-job-123", "token-123") is False
+
+    @patch.dict(os.environ, {"LOCKS_TABLE": "test-locks-table"})
+    @patch("services.lock_service.dynamodb")
+    def test_lock_token_does_not_match_a_stale_lock(self, mock_dynamodb):
+        """
+        A stale lock reads as absent in get_lock_status, and acquire_lock will hand it to
+        someone else, so its token must not keep working.
+        """
+        # Arrange
+        mock_lock_table = Mock()
+        mock_dynamodb.Table.return_value = mock_lock_table
+        stale = int(time.time()) - STALE_LOCK_THRESHOLD - 60
+        mock_lock_table.get_item.return_value = {
+            "Item": {
+                "threat_model_id": "test-job-123",
+                "lock_token": "token-123",
+                "lock_timestamp": Decimal(str(stale)),
+            }
+        }
+
+        # Act & Assert
+        assert lock_token_matches("test-job-123", "token-123") is False
 
     @patch.dict(os.environ, {"LOCKS_TABLE": "test-locks-table"})
     @patch("services.lock_service.dynamodb")

--- a/test/app/services/test_threat_designer_service.py
+++ b/test/app/services/test_threat_designer_service.py
@@ -154,8 +154,10 @@ class TestInvokeLambda:
     @patch.object(threat_designer_service, "backup_table")
     @patch.object(threat_designer_service, "table")
     @patch.object(threat_designer_service, "dynamodb")
+    @patch("services.lock_service.get_lock_status", return_value={"locked": False})
     def test_invoke_lambda_creates_backup_before_replay(
         self,
+        mock_lock_status,
         mock_dynamodb,
         mock_status_table,
         mock_backup_table,
@@ -281,6 +283,18 @@ class TestInvokeLambdaAuthorization:
     ACCESS_OWNER = {"has_access": True, "is_owner": True, "access_level": "OWNER"}
     ACCESS_EDITOR = {"has_access": True, "is_owner": False, "access_level": "EDIT"}
 
+    @pytest.fixture(autouse=True)
+    def unlocked(self):
+        """
+        Replay refuses to run while another user holds the edit lock. These tests are
+        about authorization, so default to no lock held; the lock cases have their own
+        class below.
+        """
+        with patch(
+            "services.lock_service.get_lock_status", return_value={"locked": False}
+        ) as mock_lock_status:
+            yield mock_lock_status
+
     @staticmethod
     def _assert_nothing_written(mock_status_table, mock_agent_client, mock_create_item):
         mock_status_table.put_item.assert_not_called()
@@ -348,9 +362,13 @@ class TestInvokeLambdaAuthorization:
     ):
         """
         An editor may mirror the roster. get_collaborators already exposes it to anyone
-        with access, so access to the parent is the whole boundary here.
+        with access, so access to the parent is the whole boundary here. The parent's
+        owner is left off the copied roster, since they own the fork too.
         """
         mock_require_access.return_value = self.ACCESS_EDITOR
+        mock_dynamodb.Table.return_value.get_item.return_value = {
+            "Item": {"job_id": "parent-job", "owner": "alice-123"}
+        }
 
         result = invoke_lambda(
             "editor-456",
@@ -362,7 +380,9 @@ class TestInvokeLambdaAuthorization:
             },
         )
 
-        mock_copy_sharing.assert_called_once_with("parent-job", result["id"])
+        mock_copy_sharing.assert_called_once_with(
+            "parent-job", result["id"], skip_user_id="alice-123"
+        )
 
     @patch("services.threat_designer_service._copy_sharing_records")
     @patch("utils.authorization.require_access")
@@ -376,8 +396,11 @@ class TestInvokeLambdaAuthorization:
         mock_backup_table,
         mock_agent_client,
     ):
-        """An editor may version the model; only the roster copy is owner-gated."""
+        """An editor may version the model without mirroring the roster."""
         mock_require_access.return_value = self.ACCESS_EDITOR
+        mock_dynamodb.Table.return_value.get_item.return_value = {
+            "Item": {"job_id": "parent-job", "owner": "alice-123"}
+        }
 
         result = invoke_lambda(
             "editor-456",
@@ -402,6 +425,9 @@ class TestInvokeLambdaAuthorization:
     ):
         """The owner may carry their own collaborator roster onto a new version."""
         mock_require_access.return_value = self.ACCESS_OWNER
+        mock_dynamodb.Table.return_value.get_item.return_value = {
+            "Item": {"job_id": "parent-job", "owner": "user-123"}
+        }
 
         result = invoke_lambda(
             "user-123",
@@ -413,7 +439,9 @@ class TestInvokeLambdaAuthorization:
             },
         )
 
-        mock_copy_sharing.assert_called_once_with("parent-job", result["id"])
+        mock_copy_sharing.assert_called_once_with(
+            "parent-job", result["id"], skip_user_id="user-123"
+        )
 
     @patch("utils.authorization.require_access")
     def test_replay_and_version_together_rejected(
@@ -519,6 +547,283 @@ class TestInvokeLambdaAuthorization:
 
         assert result == {"id": "some-job"}
         mock_require_access.assert_not_called()
+
+
+# ============================================================================
+# Tests for replay/version side effects: edit lock, backup slot, fork ownership
+# ============================================================================
+
+
+@patch.object(threat_designer_service, "agent_core_client")
+@patch.object(threat_designer_service, "backup_table")
+@patch.object(threat_designer_service, "table")
+@patch.object(threat_designer_service, "dynamodb")
+@patch("services.threat_designer_service.create_dynamodb_item")
+@patch("utils.authorization.require_access")
+class TestReplayAndVersionSideEffects:
+    """
+    Replay rewrites a threat model in place and version forks one. Both have to respect
+    what other users are doing to the model they touch.
+    """
+
+    PARENT = {"Item": {"job_id": "parent-job", "owner": "alice-123"}}
+
+    def test_replay_refused_while_another_user_holds_the_lock(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """Replaying over someone's in-flight edits would discard them silently."""
+        mock_dynamodb.Table.return_value.get_item.return_value = self.PARENT
+
+        with patch(
+            "services.lock_service.get_lock_status",
+            return_value={
+                "locked": True,
+                "user_id": "bob-456",
+                "username": "bob",
+                "since": "2026-09-01T00:00:00Z",
+            },
+        ):
+            with pytest.raises(ConflictError) as exc_info:
+                invoke_lambda("alice-123", {"id": "parent-job", "replay": True})
+
+        assert "bob" in str(exc_info.value)
+        mock_status_table.put_item.assert_not_called()
+        mock_agent_client.invoke_agent_runtime.assert_not_called()
+        mock_backup_table.put_item.assert_not_called()
+
+    def test_replay_allowed_while_caller_holds_the_lock(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """The caller's own lock is not an obstacle to their own replay."""
+        mock_dynamodb.Table.return_value.get_item.return_value = self.PARENT
+
+        with patch(
+            "services.lock_service.get_lock_status",
+            return_value={"locked": True, "user_id": "alice-123", "username": "alice"},
+        ):
+            result = invoke_lambda("alice-123", {"id": "parent-job", "replay": True})
+
+        assert result == {"id": "parent-job"}
+        mock_agent_client.invoke_agent_runtime.assert_called_once()
+
+    def test_replay_backup_holds_the_state_from_before_this_replay(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """
+        The write is unconditional so the slot tracks the most recent replay, which is
+        what "Restore previous version" and the auto-restore on stop both expect.
+        """
+        mock_dynamodb.Table.return_value.get_item.return_value = self.PARENT
+
+        with patch(
+            "services.lock_service.get_lock_status", return_value={"locked": False}
+        ):
+            invoke_lambda("alice-123", {"id": "parent-job", "replay": True})
+
+        kwargs = mock_backup_table.put_item.call_args[1]
+        assert kwargs["Item"] == self.PARENT["Item"]
+        assert "ConditionExpression" not in kwargs
+
+    def test_backup_write_failures_still_raise(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """Losing the backup for any other reason must not pass silently."""
+        mock_dynamodb.Table.return_value.get_item.return_value = self.PARENT
+        mock_backup_table.put_item.side_effect = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": ""}},
+            "PutItem",
+        )
+
+        with patch(
+            "services.lock_service.get_lock_status", return_value={"locked": False}
+        ):
+            with pytest.raises(InternalError):
+                invoke_lambda("alice-123", {"id": "parent-job", "replay": True})
+
+    def test_version_by_collaborator_is_owned_by_the_parents_owner(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """
+        The agent's finalize reads owner off the parent, so the fork has to be created
+        under the parent's owner or ownership flips partway through the run.
+        """
+        mock_require_access.return_value = {
+            "has_access": True,
+            "is_owner": False,
+            "access_level": "EDIT",
+        }
+        mock_dynamodb.Table.return_value.get_item.return_value = self.PARENT
+
+        result = invoke_lambda(
+            "editor-456",
+            {"id": "parent-job", "s3_location": "new-key.png", "version": True},
+        )
+
+        status_item = mock_status_table.put_item.call_args[1]["Item"]
+        assert status_item["owner"] == "alice-123"
+        assert status_item["execution_owner"] == "editor-456"
+
+        agent_state = mock_create_item.call_args[0][0]
+        assert agent_state["job_id"] == result["id"]
+        assert agent_state["owner"] == "alice-123"
+
+    def test_version_grants_its_creator_access_when_they_are_not_the_owner(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """Otherwise a collaborator cannot reach the version they just created."""
+        mock_require_access.return_value = {
+            "has_access": True,
+            "is_owner": False,
+            "access_level": "EDIT",
+        }
+        mock_sharing_table = Mock()
+        mock_dynamodb.Table.return_value = mock_sharing_table
+        mock_sharing_table.get_item.return_value = self.PARENT
+
+        result = invoke_lambda(
+            "editor-456",
+            {"id": "parent-job", "s3_location": "new-key.png", "version": True},
+        )
+
+        grant = mock_sharing_table.put_item.call_args[1]["Item"]
+        assert grant["threat_model_id"] == result["id"]
+        assert grant["user_id"] == "editor-456"
+        assert grant["access_level"] == "EDIT"
+        assert grant["owner"] == "alice-123"
+
+    def test_version_grant_mirrors_read_only_access_rather_than_widening_it(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """
+        Versioning only requires READ_ONLY, so a fixed EDIT grant would let a read-only
+        collaborator write to a model sitting in the owner's catalog.
+        """
+        mock_require_access.return_value = {
+            "has_access": True,
+            "is_owner": False,
+            "access_level": "READ_ONLY",
+        }
+        mock_sharing_table = Mock()
+        mock_dynamodb.Table.return_value = mock_sharing_table
+        mock_sharing_table.get_item.return_value = self.PARENT
+
+        invoke_lambda(
+            "reader-789",
+            {"id": "parent-job", "s3_location": "new-key.png", "version": True},
+        )
+
+        grant = mock_sharing_table.put_item.call_args[1]["Item"]
+        assert grant["user_id"] == "reader-789"
+        assert grant["access_level"] == "READ_ONLY"
+
+    def test_version_by_owner_grants_no_sharing_record(
+        self,
+        mock_require_access,
+        mock_create_item,
+        mock_dynamodb,
+        mock_status_table,
+        mock_backup_table,
+        mock_agent_client,
+    ):
+        """A record naming the owner is rejected everywhere else, so do not mint one."""
+        mock_require_access.return_value = {
+            "has_access": True,
+            "is_owner": True,
+            "access_level": "OWNER",
+        }
+        mock_sharing_table = Mock()
+        mock_dynamodb.Table.return_value = mock_sharing_table
+        mock_sharing_table.get_item.return_value = self.PARENT
+
+        invoke_lambda(
+            "alice-123",
+            {"id": "parent-job", "s3_location": "new-key.png", "version": True},
+        )
+
+        mock_sharing_table.put_item.assert_not_called()
+        agent_state = mock_create_item.call_args[0][0]
+        assert agent_state["owner"] == "alice-123"
+        assert "is_shared" not in agent_state
+
+
+class TestFetchSharedExcludesOwnModels:
+    """
+    The catalog the UI renders comes from /owned and /shared, so a sharing record naming
+    a model's own owner would show that model twice, once of them as read-only.
+    """
+
+    @patch.object(threat_designer_service, "dynamodb")
+    @patch("services.threat_designer_service._batch_fetch_threat_models")
+    def test_own_model_is_not_returned_as_shared(
+        self, mock_batch_fetch, mock_dynamodb
+    ):
+        mock_sharing_table = Mock()
+        mock_dynamodb.Table.return_value = mock_sharing_table
+        mock_sharing_table.query.return_value = {
+            "Items": [
+                {
+                    "threat_model_id": "own-job",
+                    "user_id": "user-123",
+                    "access_level": "READ_ONLY",
+                },
+                {
+                    "threat_model_id": "shared-job",
+                    "user_id": "user-123",
+                    "access_level": "EDIT",
+                },
+            ]
+        }
+        mock_batch_fetch.return_value = {
+            "own-job": {"job_id": "own-job", "owner": "user-123"},
+            "shared-job": {"job_id": "shared-job", "owner": "someone-else"},
+        }
+
+        result = threat_designer_service.fetch_shared_paginated("user-123", 10)
+
+        job_ids = [item["job_id"] for item in result["catalogs"]]
+        assert job_ids == ["shared-job"]
 
 
 # ============================================================================
@@ -778,6 +1083,28 @@ class TestFetchResults:
 
 class TestUpdateResults:
     """Tests for update_results function."""
+
+    @pytest.fixture(autouse=True)
+    def lock_token_comparison(self):
+        """
+        update_results compares the caller's token with lock_service.lock_token_matches
+        rather than reading it out of get_lock_status, so that the token never reaches an
+        HTTP response. The tests below still describe the held token in their
+        get_lock_status mock, so defer to whatever that mock reports.
+        """
+        from services import lock_service
+
+        def _matches(threat_model_id, lock_token):
+            # Read the mock's configured return value rather than calling it, so this
+            # does not disturb the call counts the tests assert on.
+            status = getattr(lock_service.get_lock_status, "return_value", None)
+            held = status.get("lock_token") if isinstance(status, dict) else None
+            return held == lock_token
+
+        with patch(
+            "services.lock_service.lock_token_matches", side_effect=_matches
+        ) as mock_matches:
+            yield mock_matches
 
     @patch.dict(
         "os.environ",


### PR DESCRIPTION
- Replay is refused with 409 while another user holds the edit lock, MCP included. It rewrites the model wholesale and was the only EDIT-level write bypassing the lock. Pre-check only: the lock can still be taken before the agent finalizes.
- A version belongs to the owner of the model it forks, from creation, matching what the agent's finalize already did. Its creator gets the access they hold on the parent, so versioning cannot widen a read-only collaborator's access.
- lock_token no longer comes back from get_lock_status, which any user with read access receives. update_results uses lock_service.lock_token_matches instead.
- fetch_shared_paginated no longer returns models the caller owns.

Also: check_access's NotFoundError now surfaces as 404 rather than 500 on get_collaborators, remove_collaborator and force_release_lock; _copy_sharing_records raises instead of reporting an empty roster as success; the dead is_shared write is gone. Frontend: a refused replay and a failed create both surface instead of failing silently, and the useAlert callbacks are memoized.
